### PR TITLE
feat(attribute): make HeuristicAttributor's empty result self-describing

### DIFF
--- a/src/agentdebug/diagnose/attribute/attribution.py
+++ b/src/agentdebug/diagnose/attribute/attribution.py
@@ -67,6 +67,14 @@ class AttributionResult:
 class Attributor(Protocol):
     id: str
 
+    #: Whether this attributor needs detector findings to produce anything at all.
+    #:
+    #: Read it with `getattr(attributor, 'requires_findings', False)`: it is documented on the
+    #: protocol so callers can branch on it, but every existing third-party Attributor that
+    #: predates this field keeps satisfying the protocol without declaring it, and False is
+    #: the correct default for an attributor that reads the trajectory directly.
+    requires_findings: bool
+
     def attribute(
         self,
         trajectory: AgentTrajectory,
@@ -76,9 +84,29 @@ class Attributor(Protocol):
 
 
 class HeuristicAttributor:
-    """Cheap, model-free fallback that picks the earliest highest-confidence finding."""
+    """Cheap, model-free fallback that picks the earliest highest-confidence finding.
+
+    Requires detector findings. It ranks findings; it does not derive them, so calling
+    `attribute(trajectory)` with no `findings` can only ever return zero hypotheses. Run it
+    through `DiagnosePipeline` (which detects first and passes findings in), or pass findings
+    yourself. See `requires_findings`.
+    """
 
     id = 'heuristic'
+
+    #: This attributor cannot produce hypotheses from a trajectory alone.
+    #:
+    #: Exposed so callers can tell "no findings were supplied" apart from "the trajectory
+    #: contains no attributable failure" BEFORE spending anything. The motivating case: a
+    #: downstream harness used the bare attributor as a fallback for when `DiagnosePipeline`
+    #: raised, and measured `heuristic` as returning no hypotheses on 5 of 5 trajectories --
+    #: not because the trajectories were clean, but because a findings-less call is empty by
+    #: construction. Under the pipeline the same attributor produced hypotheses on 3 of those
+    #: 5. A fallback to the bare attributor is therefore not a safety net for this attributor;
+    #: it is a guaranteed empty result that looks like a verdict.
+    #:
+    #: Other attributors in this module leave it False: they read the trajectory directly.
+    requires_findings: bool = True
 
     def attribute(
         self,
@@ -87,7 +115,21 @@ class HeuristicAttributor:
     ) -> AttributionResult:
         findings = findings or []
         if not findings:
-            return AttributionResult(method=self.id, hypotheses=[])
+            # Empty, as before -- but say why, so an empty result is self-describing rather
+            # than indistinguishable from "nothing to blame here". `raw` is already a
+            # defaulted dict on AttributionResult, so nothing about the shape changes.
+            return AttributionResult(
+                method=self.id,
+                hypotheses=[],
+                raw={
+                    'reason': 'no_findings_supplied',
+                    'detail': (
+                        'HeuristicAttributor ranks detector findings and cannot derive them. '
+                        'Call it through DiagnosePipeline, or pass findings= explicitly.'
+                    ),
+                    'requires_findings': True,
+                },
+            )
         ranked = sorted(
             findings,
             key=lambda f: (

--- a/tests/test_diagnose_attribute.py
+++ b/tests/test_diagnose_attribute.py
@@ -36,6 +36,30 @@ def test_heuristic_attributor_handles_no_findings(
     assert HeuristicAttributor().attribute(failed_trajectory).hypotheses == []
 
 
+def test_heuristic_attributor_says_why_it_returned_nothing(
+    failed_trajectory: AgentTrajectory,
+) -> None:
+    """An empty result must be distinguishable from "nothing to blame in this trajectory".
+
+    A downstream harness used the bare attributor as a fallback for a failing
+    DiagnosePipeline and measured heuristic returning no hypotheses on 5 of 5 trajectories.
+    Those trajectories were not clean: a findings-less call is empty by construction, and
+    under the pipeline the same attributor produced hypotheses on 3 of the 5. The emptiness
+    now carries its own explanation.
+    """
+    result = HeuristicAttributor().attribute(failed_trajectory)
+    assert result.hypotheses == []
+    assert result.raw['reason'] == 'no_findings_supplied'
+    assert 'findings' in result.raw['detail']
+
+
+def test_requires_findings_lets_a_caller_check_before_spending() -> None:
+    """Callers choose attributors dynamically; this is how they avoid a guaranteed-empty call."""
+    assert HeuristicAttributor.requires_findings is True
+    # Attributors that read the trajectory directly need not declare it; absent means False.
+    assert getattr(AllAtOnceAttributor, 'requires_findings', False) is False
+
+
 def test_all_at_once_normalizes_ordinal_to_real_event(
     failed_trajectory: AgentTrajectory,
 ) -> None:


### PR DESCRIPTION
## What

`HeuristicAttributor` ranks detector findings; it does not derive them. So `attribute(trajectory)` with no `findings` returns zero hypotheses **by construction**, and the caller receives a well-formed `AttributionResult` that is indistinguishable from *"this trajectory contains nothing to blame"*.

## How it surfaced (measured, not theorised)

A downstream harness used the bare attributor as a fallback for when `DiagnosePipeline` raises. It recorded `heuristic` returning no hypotheses on **5 of 5** trajectories. The trajectories were not clean — under `DiagnosePipeline`, which detects first and passes findings in, the *same* attributor produced hypotheses on **3 of those 5**; the other 2 were genuinely empty on both paths.

| attributor | pipeline only | both produced | both empty | direct only |
|---|---|---|---|---|
| `heuristic` | 3 | 0 | 2 | 0 |
| `all_at_once` | 0 | 5 | 0 | 0 |
| `binary_search` | 0 | 5 | 0 | 0 |

So a fallback to the bare attributor is not a safety net for this attributor — it is a guaranteed empty result wearing the shape of a verdict. `all_at_once` and `binary_search` read the trajectory directly and are unaffected.

## Changes — both additive, no behaviour change

- the empty result carries `raw={'reason': 'no_findings_supplied', 'detail': ...}`. `AttributionResult.raw` is already a defaulted dict, so the shape is unchanged and the existing test asserting `hypotheses == []` still passes.
- `requires_findings: bool = True` on `HeuristicAttributor`, documented on the `Attributor` protocol, so a caller choosing an attributor dynamically can check before spending. Read it as `getattr(a, 'requires_findings', False)` — third-party attributors predating the field keep satisfying the protocol, and `False` is correct for anything reading the trajectory directly.

## Tests

`187 passed, 7 skipped`. Two new tests: one asserting the empty result explains itself, one asserting a caller can branch on `requires_findings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)