### PR TITLE
feat(attribute): awaitable attribution without making any attributor async

### DIFF
--- a/src/agentdebug/diagnose/attribute/__init__.py
+++ b/src/agentdebug/diagnose/attribute/__init__.py
@@ -3,6 +3,11 @@
 Attribution traces observed failures back to the responsible step or agent.
 """
 
+from agentdebug.diagnose.attribute.async_api import (
+    attribute_async,
+    attribute_many_async,
+    supports_native_async,
+)
 from agentdebug.diagnose.attribute.attribution import (
     AllAtOnceAttributor,
     AttributionBudget,
@@ -37,4 +42,7 @@ __all__ = [
     'HeuristicAttributor',
     'SBFLAttributor',
     'StepByStepAttributor',
+    'attribute_async',
+    'attribute_many_async',
+    'supports_native_async',
 ]

--- a/src/agentdebug/diagnose/attribute/async_api.py
+++ b/src/agentdebug/diagnose/attribute/async_api.py
@@ -1,0 +1,119 @@
+"""Awaitable attribution, without requiring any attributor to become async.
+
+Attribution is the slowest stage in a debugging pipeline and the most obviously
+parallel: attributing N trajectories, or comparing M attributors on one trajectory,
+are both embarrassingly concurrent. But `Attributor.attribute` is synchronous, so
+every async caller ends up writing its own `asyncio.to_thread(...)` hop. Downstream
+harnesses have each grown a private copy of that line, and copies drift: one forgets
+the concurrency cap and opens as many provider connections as there are traces, another
+wraps the batch in a bare `except` and reports a provider error as "no hypotheses".
+
+This module is the shared version. It adds nothing to the `Attributor` protocol that
+existing implementations must satisfy:
+
+* Sync-only attributors -- every one shipped today, and every third-party one -- work
+  unchanged. They are run off the event loop in a worker thread.
+* An attributor that *is* natively async may declare an optional `attribute_async`
+  coroutine method. When present it is awaited directly and no thread is used. Nothing
+  requires it, and `Attributor` does not gain a mandatory member.
+
+The result is the same `AttributionResult` either way, `usage` included, so cost
+accounting is unaffected by which path ran.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any, List, Optional, Sequence, Union
+
+from agentdebug.diagnose.attribute.attribution import AttributionResult
+from agentdebug.schema import AgentTrajectory, FailureFinding
+
+__all__ = ['attribute_async', 'attribute_many_async', 'supports_native_async']
+
+#: Default ceiling on in-flight attributions. Chosen to be small: each one is usually an
+#: LLM call, providers rate-limit per key, and an unbounded `gather` over a few hundred
+#: traces reliably turns a slow run into a failed one.
+DEFAULT_CONCURRENCY = 4
+
+
+def supports_native_async(attributor: Any) -> bool:
+    """Whether `attributor` implements the optional `attribute_async` coroutine method.
+
+    Exposed so a caller can report which path it took rather than guess. A plain
+    `hasattr` is not enough: a sync method named `attribute_async` would satisfy it and
+    then fail to await, so the callable is also checked for being a coroutine function.
+    """
+    candidate = getattr(attributor, 'attribute_async', None)
+    if candidate is None:
+        return False
+    return inspect.iscoroutinefunction(candidate)
+
+
+async def attribute_async(
+    attributor: Any,
+    trajectory: AgentTrajectory,
+    findings: Optional[List[FailureFinding]] = None,
+) -> AttributionResult:
+    """Await one attribution, natively if the attributor supports it and off-thread if not.
+
+    Equivalent to `attributor.attribute(trajectory, findings)` in every respect except
+    that it does not block the event loop.
+
+    Note on `findings`: attributors that declare `requires_findings = True` still require
+    them here. Passing `None` to one of those returns an empty result by construction, not
+    because the trajectory is clean -- see `HeuristicAttributor.requires_findings`.
+    """
+    if supports_native_async(attributor):
+        return await attributor.attribute_async(trajectory, findings)
+    return await asyncio.to_thread(attributor.attribute, trajectory, findings)
+
+
+async def attribute_many_async(
+    attributor: Any,
+    trajectories: Sequence[AgentTrajectory],
+    findings: Optional[Sequence[Optional[List[FailureFinding]]]] = None,
+    *,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    return_exceptions: bool = False,
+) -> List[Union[AttributionResult, BaseException]]:
+    """Attribute many trajectories concurrently, bounded, and in input order.
+
+    `findings` is aligned to `trajectories` by index when given; a `None` entry means no
+    findings for that trajectory. Supplying a sequence of a different length is a
+    programming error and raises rather than silently attributing the wrong findings to
+    the wrong trace.
+
+    `return_exceptions=False` (the default) propagates the first failure, matching
+    `asyncio.gather`. Pass `True` to get a list positionally aligned with the input in
+    which failures appear as exception objects.
+
+    That flag exists because of a specific failure mode seen downstream: a caller
+    comparing attributors wrapped the whole batch in `try/except` and recorded a provider
+    error as "this attributor found nothing", which is indistinguishable from a real
+    verdict of no-error and quietly understated one attributor against the others. Keeping
+    the exception in the result makes an infrastructure failure impossible to confuse with
+    a finding. An outage is not a measurement.
+    """
+    if concurrency < 1:
+        raise ValueError(f'concurrency must be >= 1, got {concurrency}')
+    if findings is not None and len(findings) != len(trajectories):
+        raise ValueError(
+            f'findings has length {len(findings)} but there are {len(trajectories)} '
+            'trajectories; they are matched by index'
+        )
+    if not trajectories:
+        return []
+
+    limit = asyncio.Semaphore(concurrency)
+
+    async def _one(index: int) -> AttributionResult:
+        async with limit:
+            per_trace = findings[index] if findings is not None else None
+            return await attribute_async(attributor, trajectories[index], per_trace)
+
+    return await asyncio.gather(
+        *(_one(i) for i in range(len(trajectories))),
+        return_exceptions=return_exceptions,
+    )

--- a/tests/test_attribute_async.py
+++ b/tests/test_attribute_async.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from agentdebug.diagnose.attribute import (
+    HeuristicAttributor,
+    attribute_async,
+    attribute_many_async,
+    supports_native_async,
+)
+from agentdebug.diagnose.attribute.attribution import AttributionResult, Blame
+from agentdebug.schema import AgentTrajectory, FailureFinding, FailureMode
+
+
+def _blame(span_id: str, *, step_index: int = 1, confidence: float = 0.5) -> Blame:
+    """Blame requires span_id, step_index, agent_name, confidence and rationale."""
+    return Blame(
+        span_id=span_id,
+        step_index=step_index,
+        agent_name='a',
+        confidence=confidence,
+        rationale='test fixture',
+    )
+
+
+def _result(*hypotheses: Blame, method: str = 'test') -> AttributionResult:
+    return AttributionResult(method=method, hypotheses=list(hypotheses))
+
+
+class _SyncOnlyAttributor:
+    """Stands in for every attributor shipped today, and every third-party one."""
+
+    id = 'sync_only'
+    requires_findings = False
+
+    def __init__(self) -> None:
+        self.threads: list[int] = []
+        self.calls = 0
+
+    def attribute(self, trajectory, findings=None):  # noqa: ANN001, ANN201
+        self.calls += 1
+        self.threads.append(threading.get_ident())
+        return _result(_blame(f'evt_{self.calls}'))
+
+
+class _NativeAsyncAttributor:
+    """Opts into the optional coroutine hook; must never be run in a thread."""
+
+    id = 'native'
+    requires_findings = False
+
+    def __init__(self) -> None:
+        self.threads: list[int] = []
+
+    def attribute(self, trajectory, findings=None):  # noqa: ANN001, ANN201
+        raise AssertionError('the sync path must not be used when attribute_async exists')
+
+    async def attribute_async(self, trajectory, findings=None):  # noqa: ANN001, ANN201
+        self.threads.append(threading.get_ident())
+        return _result(_blame('evt_native', confidence=0.9))
+
+
+class _FakeAsyncNameAttributor:
+    """`attribute_async` exists but is NOT a coroutine function -- awaiting it would fail."""
+
+    id = 'fake_async'
+    requires_findings = False
+
+    def attribute(self, trajectory, findings=None):  # noqa: ANN001, ANN201
+        return _result(_blame('evt_sync'))
+
+    def attribute_async(self, trajectory, findings=None):  # noqa: ANN001, ANN201
+        raise AssertionError('a non-coroutine attribute_async must not be awaited')
+
+
+class _ExplodingAttributor:
+    id = 'exploding'
+    requires_findings = False
+
+    def attribute(self, trajectory, findings=None):  # noqa: ANN001, ANN201
+        raise RuntimeError('provider returned 503')
+
+
+def test_supports_native_async_requires_an_actual_coroutine() -> None:
+    assert supports_native_async(_NativeAsyncAttributor()) is True
+    assert supports_native_async(_SyncOnlyAttributor()) is False
+    # The trap: present, callable, correctly named, and still not awaitable.
+    assert supports_native_async(_FakeAsyncNameAttributor()) is False
+
+
+@pytest.mark.asyncio
+async def test_sync_attributor_runs_off_the_event_loop_thread(
+    failed_trajectory: AgentTrajectory,
+) -> None:
+    attributor = _SyncOnlyAttributor()
+
+    result = await attribute_async(attributor, failed_trajectory)
+
+    assert result.hypotheses[0].span_id == 'evt_1'
+    assert attributor.threads == [attributor.threads[0]]
+    assert attributor.threads[0] != threading.get_ident(), 'must not block the loop thread'
+
+
+@pytest.mark.asyncio
+async def test_native_async_attributor_is_awaited_directly(
+    failed_trajectory: AgentTrajectory,
+) -> None:
+    attributor = _NativeAsyncAttributor()
+
+    result = await attribute_async(attributor, failed_trajectory)
+
+    assert result.hypotheses[0].span_id == 'evt_native'
+    # No thread hop: a natively-async attributor should not pay for one.
+    assert attributor.threads == [threading.get_ident()]
+
+
+@pytest.mark.asyncio
+async def test_a_non_coroutine_attribute_async_falls_back_to_the_sync_path(
+    failed_trajectory: AgentTrajectory,
+) -> None:
+    result = await attribute_async(_FakeAsyncNameAttributor(), failed_trajectory)
+    assert result.hypotheses[0].span_id == 'evt_sync'
+
+
+@pytest.mark.asyncio
+async def test_findings_still_reach_a_requires_findings_attributor(
+    failed_trajectory: AgentTrajectory,
+    failure_mode: FailureMode,
+) -> None:
+    finding = FailureFinding(
+        failure_mode=failure_mode,
+        event_id='evt_plan',
+        agent_name='planner',
+        step_index=1,
+        confidence=0.4,
+    )
+
+    with_findings = await attribute_async(HeuristicAttributor(), failed_trajectory, [finding])
+    assert with_findings.hypotheses[0].span_id == 'evt_plan'
+
+    # And the documented trap survives the async wrapper: no findings means empty by
+    # construction, not a clean trajectory.
+    without = await attribute_async(HeuristicAttributor(), failed_trajectory)
+    assert without.hypotheses == []
+
+
+@pytest.mark.asyncio
+async def test_many_preserves_input_order(failed_trajectory: AgentTrajectory) -> None:
+    attributor = _SyncOnlyAttributor()
+    trajectories = [failed_trajectory] * 5
+
+    results = await attribute_many_async(attributor, trajectories, concurrency=5)
+
+    assert len(results) == 5
+    assert attributor.calls == 5
+    # Completion order under concurrency is arbitrary; the returned order is not.
+    assert [r.hypotheses[0].span_id for r in results] == sorted(
+        r.hypotheses[0].span_id for r in results
+    ), 'results must be positionally aligned with the input'
+
+
+@pytest.mark.asyncio
+async def test_many_respects_the_concurrency_ceiling(
+    failed_trajectory: AgentTrajectory,
+) -> None:
+    peak = 0
+    live = 0
+    lock = threading.Lock()
+
+    class _Counting:
+        id = 'counting'
+        requires_findings = False
+
+        def attribute(self, trajectory, findings=None):  # noqa: ANN001, ANN201
+            nonlocal peak, live
+            with lock:
+                live += 1
+                peak = max(peak, live)
+            try:
+                # Long enough that an unbounded gather would overlap all ten.
+                threading.Event().wait(0.05)
+            finally:
+                with lock:
+                    live -= 1
+            return _result()
+
+    await attribute_many_async(_Counting(), [failed_trajectory] * 10, concurrency=3)
+
+    assert peak <= 3, f'concurrency ceiling of 3 was exceeded: peak {peak}'
+
+
+@pytest.mark.asyncio
+async def test_many_can_return_failures_instead_of_swallowing_them(
+    failed_trajectory: AgentTrajectory,
+) -> None:
+    """The point of return_exceptions: a 503 must not read as "found nothing".
+
+    A downstream harness recorded provider errors as empty attributions, which is
+    indistinguishable from a genuine verdict of no-error and silently understated one
+    attributor against the others.
+    """
+    results = await attribute_many_async(
+        _ExplodingAttributor(), [failed_trajectory] * 2, return_exceptions=True
+    )
+
+    assert len(results) == 2
+    assert all(isinstance(r, RuntimeError) for r in results)
+    assert 'provider returned 503' in str(results[0])
+
+
+@pytest.mark.asyncio
+async def test_many_propagates_by_default(failed_trajectory: AgentTrajectory) -> None:
+    with pytest.raises(RuntimeError, match='provider returned 503'):
+        await attribute_many_async(_ExplodingAttributor(), [failed_trajectory])
+
+
+@pytest.mark.asyncio
+async def test_many_rejects_misaligned_findings(failed_trajectory: AgentTrajectory) -> None:
+    with pytest.raises(ValueError, match='matched by index'):
+        await attribute_many_async(
+            _SyncOnlyAttributor(), [failed_trajectory] * 3, findings=[None, None]
+        )
+
+
+@pytest.mark.asyncio
+async def test_many_rejects_a_nonsense_concurrency(
+    failed_trajectory: AgentTrajectory,
+) -> None:
+    with pytest.raises(ValueError, match='concurrency must be'):
+        await attribute_many_async(
+            _SyncOnlyAttributor(), [failed_trajectory], concurrency=0
+        )
+
+
+@pytest.mark.asyncio
+async def test_many_on_an_empty_sequence_is_empty_not_an_error() -> None:
+    assert await attribute_many_async(_SyncOnlyAttributor(), []) == []
+
+
+@pytest.mark.asyncio
+async def test_usage_survives_both_paths(failed_trajectory: AgentTrajectory) -> None:
+    """Cost accounting must not depend on which path ran."""
+    sync_result = await attribute_async(_SyncOnlyAttributor(), failed_trajectory)
+    native_result = await attribute_async(_NativeAsyncAttributor(), failed_trajectory)
+
+    for result in (sync_result, native_result):
+        assert result.usage is not None
+        assert result.usage.total_tokens == 0
+
+
+def test_the_sync_api_is_untouched(failed_trajectory: AgentTrajectory) -> None:
+    """No existing caller has to change: attribute() still works with no event loop."""
+    assert _SyncOnlyAttributor().attribute(failed_trajectory).hypotheses[0].span_id == 'evt_1'
+    assert asyncio.get_event_loop_policy() is not None


### PR DESCRIPTION
## Why

Attribution is the slowest stage in a debugging pipeline and the most obviously parallel: attributing N trajectories, or comparing M attributors on one trajectory, are both embarrassingly concurrent. But `Attributor.attribute` is synchronous, so every async caller ends up writing its own `asyncio.to_thread(...)` hop.

Those private copies drift. Two failure modes seen in a downstream harness:

- one omitted the concurrency cap and opened as many provider connections as there were traces;
- another wrapped the batch in a bare `except` and recorded a provider error as "this attributor found nothing" — indistinguishable from a genuine verdict of no-error, which silently understated one attributor against the others in a comparison.

## What

```python
attribute_async(attributor, trajectory, findings=None)
attribute_many_async(attributor, trajectories, findings=None, *,
                     concurrency=4, return_exceptions=False)
supports_native_async(attributor)
```

Exported from `agentdebug.diagnose.attribute`.

## Backward compatibility is the design constraint

- **Every attributor shipped today, and every third-party one, works unchanged.** Sync attributors are run off the event loop in a worker thread. The `Attributor` protocol gains **no mandatory member**.
- An attributor that *is* natively async may declare an **optional** `attribute_async` coroutine method. When present it is awaited directly and no thread is used. Nothing requires it.
- `supports_native_async` checks `inspect.iscoroutinefunction` rather than `hasattr`, because a *sync* method merely named `attribute_async` would otherwise be awaited and blow up. There is a test for exactly that trap.
- The same `AttributionResult` comes back on both paths, `usage` included, so the token accounting from #2 does not depend on which path ran. Also tested.

## Design notes

- `return_exceptions` defaults to `False`, matching `asyncio.gather`. Passing `True` returns failures as exception objects positionally aligned with the input, so an infrastructure outage cannot be mistaken for a finding.
- `concurrency` defaults to 4 and is validated. Providers rate-limit per key, and an unbounded `gather` over a few hundred traces reliably turns a slow run into a failed one.
- Misaligned `findings` raises rather than silently attributing one trace's findings to another.
- Results from `attribute_many_async` are in **input order**, not completion order.
- Python 3.9 floor respected (`asyncio.to_thread` is 3.9+; no `asyncio.timeout`).

## Tests

14 new tests in `tests/test_attribute_async.py`, covering the thread hop, the native path, the fake-async trap, findings pass-through (including that `requires_findings` attributors still return empty by construction without them), input ordering, the concurrency ceiling, both exception modes, misaligned findings, empty input, and `usage` on both paths.

Full suite: **201 passed, 7 skipped**.