### PR TITLE
feat(attribute): let a caller pin steps into BinarySearchAttributor's context window

### DIFF
--- a/src/agentdebug/diagnose/attribute/attribution.py
+++ b/src/agentdebug/diagnose/attribute/attribution.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Protocol, Tuple, cast
+from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple, cast
 
 
 # Forward decl so BinarySearchAttributor.attribute can reference _EllipsisEvent
@@ -676,7 +676,8 @@ class BinarySearchAttributor:
         *,
         fallback: Optional[Attributor] = None,
         max_tokens: int = 4096,
-        context_window: int = 6,
+        context_window: Optional[int] = 6,
+        always_include_steps: Optional[Sequence[int]] = None,
         use_ground_truth_context: bool = False,
     ) -> None:
         # max_tokens default doubled in 0.2.4: thinking models (Gemini, o-series)
@@ -685,10 +686,22 @@ class BinarySearchAttributor:
         self.llm = llm
         self.fallback: Attributor = fallback or HeuristicAttributor()
         self.max_tokens = max_tokens
-        # When formatting a prefix into the LLM prompt we only keep this many
-        # events at the head + this many at the tail; the middle is elided.
-        # Keeps cost bounded for very long trajectories.
+        # When formatting a prefix into the LLM prompt we keep this many events at the
+        # head plus this many at the tail; the middle is elided to bound cost on long
+        # trajectories. The elision is POSITIONAL, not relevance-based, so on a
+        # 30-event trajectory at the default of 6 the attributor sees steps 0-5 and
+        # 24-29 and is blind to 18 of 30 -- a constraint established mid-trajectory
+        # cannot be seen at all, however decisive it is.
+        #
+        # Two ways out, both opt-in so the default rendering is byte-identical:
+        #   * `always_include_steps` pins specific step indices into every rendered
+        #     window. A caller that already suspects a step -- a detector finding, a
+        #     judge's checkpoint, ground truth -- can guarantee the attributor sees it.
+        #   * `context_window=None` disables elision entirely.
         self.context_window = context_window
+        self.always_include_steps = (
+            frozenset(always_include_steps) if always_include_steps is not None else frozenset()
+        )
         self.use_ground_truth_context = use_ground_truth_context
 
     def attribute(
@@ -730,6 +743,10 @@ class BinarySearchAttributor:
                     self.use_ground_truth_context and _ground_truth_text(trajectory)
                 ),
                 'search_strategy': 'half_recursive',
+                # Whether prompt rendering could withhold steps from the probes, and
+                # which were pinned in regardless. Reported for the full trajectory:
+                # individual probes render shorter prefixes and elide no more than this.
+                'context_elision': self._prefix_view(list(trajectory.events))[1],
             },
         )
 
@@ -922,15 +939,57 @@ class BinarySearchAttributor:
             blocks.append('\n'.join(block))
         return '\n\n'.join(blocks) or '(empty)'
 
+    def _prefix_view(self, events: List[Any]) -> Tuple[List[Any], Dict[str, Any]]:
+        """The events a probe will actually see, plus a report of what was hidden.
+
+        Split out from `_render_prefix` so `attribute` can tell the caller whether any
+        step was withheld. Without that, a downstream harness cannot distinguish "the
+        attributor considered this step and dismissed it" from "the attributor never
+        saw it", which are very different findings about the same trajectory.
+        """
+        window = self.context_window
+        pinned = sorted(
+            {e.step_index for e in events if getattr(e, 'step_index', None) in self.always_include_steps}
+        )
+        if window is None or len(events) <= 2 * window:
+            return list(events), {
+                'elided': False,
+                'events_total': len(events),
+                'events_shown': len(events),
+                'context_window': window,
+                'pinned_steps': pinned,
+            }
+
+        head = events[:window]
+        tail = events[-window:]
+        kept_ids = {id(e) for e in head} | {id(e) for e in tail}
+        # Pinned events are restored in trajectory order, so the prompt stays monotone
+        # in step index rather than appending them out of sequence.
+        middle = [
+            e
+            for e in events[window:-window]
+            if getattr(e, 'step_index', None) in self.always_include_steps
+        ]
+        restored = [e for e in middle if id(e) not in kept_ids]
+        elided = len(events) - 2 * window - len(restored)
+        view: List[Any] = list(head)
+        if restored:
+            view.extend(restored)
+        if elided > 0:
+            view.append(_EVENT_ELLIPSIS(elided))
+        view.extend(tail)
+        return view, {
+            'elided': elided > 0,
+            'events_total': len(events),
+            'events_shown': len(events) - elided,
+            'events_elided': elided,
+            'context_window': window,
+            'pinned_steps': pinned,
+            'restored_by_pinning': len(restored),
+        }
+
     def _render_prefix(self, prefix: AgentTrajectory) -> str:
-        events = prefix.events
-        if len(events) <= 2 * self.context_window:
-            view = events
-        else:
-            head = events[: self.context_window]
-            tail = events[-self.context_window:]
-            elided = len(events) - 2 * self.context_window
-            view = head + [_EVENT_ELLIPSIS(elided)] + tail
+        view, _ = self._prefix_view(list(prefix.events))
         return '\n'.join(self._render_event(e) for e in view)
 
     @staticmethod

--- a/tests/test_binary_search_context.py
+++ b/tests/test_binary_search_context.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import re
+
+from agentdebug.diagnose.attribute import BinarySearchAttributor
+from agentdebug.schema import AgentEvent, AgentTrajectory
+
+
+def _event(i: int, *, marker: bool = False) -> AgentEvent:
+    return AgentEvent(
+        event_id=f'evt_{i:02d}',
+        trace_id='t',
+        agent_name='solver',
+        event_type='tool.call',
+        step_index=i,
+        input={'tool': 'goto', 'args': {}},
+        output='CONSTRAINT ESTABLISHED' if marker else f'step {i} ok',
+        error=None,
+    )
+
+
+def _trajectory(n: int, *, marker_at: int | None = None) -> AgentTrajectory:
+    return AgentTrajectory(
+        trace_id='t',
+        task_id='k',
+        goal='g',
+        framework='f',
+        events=[_event(i, marker=(i == marker_at)) for i in range(n)],
+    )
+
+
+def _renderer(**kwargs: object) -> BinarySearchAttributor:
+    """A BinarySearchAttributor with only the rendering state set, so no LLM is needed."""
+    a = BinarySearchAttributor.__new__(BinarySearchAttributor)
+    a.context_window = kwargs.get('context_window', 6)  # type: ignore[assignment]
+    pinned = kwargs.get('always_include_steps') or ()
+    a.always_include_steps = frozenset(pinned)  # type: ignore[arg-type,assignment]
+    return a
+
+
+def _visible_steps(rendered: str) -> list[int]:
+    return [int(x) for x in re.findall(r'step=(\d+)', rendered)]
+
+
+def test_the_default_window_hides_the_middle_of_a_long_trajectory() -> None:
+    """Documents the behaviour the options below exist to work around.
+
+    The elision is positional, not relevance-based: at the default window of 6 a
+    30-event trajectory shows only steps 0-5 and 24-29, so a constraint established at
+    step 10 is invisible however decisive it is.
+    """
+    traj = _trajectory(30, marker_at=10)
+    rendered = _renderer()._render_prefix(traj)
+
+    assert _visible_steps(rendered) == [0, 1, 2, 3, 4, 5, 24, 25, 26, 27, 28, 29]
+    assert 'CONSTRAINT ESTABLISHED' not in rendered
+    assert '18 events elided' in rendered
+
+
+def test_short_trajectories_are_never_elided() -> None:
+    traj = _trajectory(12, marker_at=6)
+    rendered = _renderer()._render_prefix(traj)
+
+    assert _visible_steps(rendered) == list(range(12))
+    assert 'elided' not in rendered
+
+
+def test_pinning_a_step_makes_it_visible_without_widening_the_window() -> None:
+    traj = _trajectory(30, marker_at=10)
+    rendered = _renderer(always_include_steps=[10])._render_prefix(traj)
+
+    assert 'CONSTRAINT ESTABLISHED' in rendered
+    # Pinned events are restored in trajectory order, so step index stays monotone.
+    assert _visible_steps(rendered) == [0, 1, 2, 3, 4, 5, 10, 24, 25, 26, 27, 28, 29]
+    # And the ellipsis count drops by exactly what was restored, so the note stays true.
+    assert '17 events elided' in rendered
+
+
+def test_pinning_several_steps_keeps_them_ordered() -> None:
+    traj = _trajectory(40)
+    rendered = _renderer(always_include_steps=[20, 8, 15])._render_prefix(traj)
+
+    visible = _visible_steps(rendered)
+    assert [8, 15, 20] == [s for s in visible if s in (8, 15, 20)]
+    assert visible == sorted(visible), 'rendered prefix must stay monotone in step index'
+
+
+def test_pinning_a_step_already_in_the_window_does_not_duplicate_it() -> None:
+    traj = _trajectory(30)
+    rendered = _renderer(always_include_steps=[2, 27])._render_prefix(traj)
+
+    visible = _visible_steps(rendered)
+    assert visible.count(2) == 1
+    assert visible.count(27) == 1
+    assert '18 events elided' in rendered, 'nothing was restored, so the count is unchanged'
+
+
+def test_pinning_a_step_that_does_not_exist_is_harmless() -> None:
+    traj = _trajectory(30)
+    rendered = _renderer(always_include_steps=[999])._render_prefix(traj)
+
+    assert _visible_steps(rendered) == [0, 1, 2, 3, 4, 5, 24, 25, 26, 27, 28, 29]
+
+
+def test_context_window_none_disables_elision() -> None:
+    traj = _trajectory(30, marker_at=10)
+    rendered = _renderer(context_window=None)._render_prefix(traj)
+
+    assert _visible_steps(rendered) == list(range(30))
+    assert 'CONSTRAINT ESTABLISHED' in rendered
+    assert 'elided' not in rendered
+
+
+def test_the_elision_report_says_what_was_withheld() -> None:
+    """A caller must be able to tell "considered and dismissed" from "never seen"."""
+    traj = _trajectory(30, marker_at=10)
+
+    _, report = _renderer()._prefix_view(list(traj.events))
+    assert report['elided'] is True
+    assert report['events_total'] == 30
+    assert report['events_shown'] == 12
+    assert report['events_elided'] == 18
+    assert report['context_window'] == 6
+    assert report['pinned_steps'] == []
+    assert report['restored_by_pinning'] == 0
+
+    _, pinned_report = _renderer(always_include_steps=[10])._prefix_view(list(traj.events))
+    assert pinned_report['events_elided'] == 17
+    assert pinned_report['pinned_steps'] == [10]
+    assert pinned_report['restored_by_pinning'] == 1
+
+    _, whole = _renderer(context_window=None)._prefix_view(list(traj.events))
+    assert whole['elided'] is False
+    assert whole['events_shown'] == 30
+
+
+def test_report_and_rendering_never_disagree_about_the_count() -> None:
+    """The ellipsis note in the prompt and the machine-readable report must match."""
+    for n in (5, 12, 13, 30, 41):
+        for pinned in ((), (7,), (7, 9, 20)):
+            r = _renderer(always_include_steps=pinned)
+            rendered = r._render_prefix(_trajectory(n))
+            _, report = r._prefix_view(list(_trajectory(n).events))
+            note = re.search(r'\((\d+) events elided\)', rendered)
+            if report['elided']:
+                assert note is not None, f'n={n} pinned={pinned}: report says elided, prompt does not'
+                assert int(note.group(1)) == report['events_elided']
+            else:
+                assert note is None, f'n={n} pinned={pinned}: prompt elides, report says it did not'
+            assert len(_visible_steps(rendered)) == report['events_shown']
+
+
+def test_constructor_defaults_are_unchanged() -> None:
+    """Existing callers must see byte-identical rendering; these options are opt-in."""
+    import inspect
+
+    sig = inspect.signature(BinarySearchAttributor.__init__)
+    assert sig.parameters['context_window'].default == 6
+    assert sig.parameters['always_include_steps'].default is None


### PR DESCRIPTION
## The problem, measured

`BinarySearchAttributor`'s prefix elision bounds prompt cost by keeping `context_window` events at the head and the same at the tail. That elision is **positional, not relevance-based**. At the default of 6, on a 30-event trajectory:

```
steps visible: [0, 1, 2, 3, 4, 5, 24, 25, 26, 27, 28, 29]
... (18 events elided) ...
```

18 of 30 events — 60% of the trajectory — are invisible. A constraint established at step 10 cannot be seen, however decisive it is. That is exactly the shape of failure binary search is supposed to be good at: a cause set early, a symptom surfacing late.

**And nothing told the caller.** `_render_prefix` returned a string, and the ellipsis note existed only inside the prompt. A downstream harness could not distinguish *"the attributor considered this step and dismissed it"* from *"the attributor never saw it"* — two very different findings about the same trajectory. This is the same class of defect #3 fixed for `HeuristicAttributor`'s empty result.

## What this adds

Three options, all opt-in. **Default rendering is byte-identical** — there is a test asserting the constructor defaults.

| addition | effect |
|---|---|
| `always_include_steps` | step indices pinned into every rendered window |
| `context_window=None` | disables elision entirely |
| `raw['context_elision']` | machine-readable report of what rendering could withhold |

With step 10 pinned:

```
steps visible: [0, 1, 2, 3, 4, 5, 10, 24, 25, 26, 27, 28, 29]
... (17 events elided) ...
```

The point of `always_include_steps` is that a caller usually *already knows* which steps are worth seeing — a detector finding, a judge's nominated checkpoint, ground truth — and can guarantee the attributor sees them without widening the window for everything and paying for it on every probe.

## Details worth reviewing

- Restored events are re-inserted **in trajectory order**, so the rendered prefix stays monotone in step index rather than appending pinned events out of sequence.
- The ellipsis count **drops by exactly what was restored**, so the note in the prompt stays true. A property test asserts the prompt's count and the report never disagree, across five trajectory lengths × three pinning sets.
- Pinning a step already inside the window does not duplicate it.
- Pinning a step that does not exist is harmless.
- `raw` was already a defaulted dict, so no result shape changes.
- The report is computed for the full trajectory; individual probes render shorter prefixes and elide no more than this. That is stated in the code comment rather than left to inference.

## Tests

10 new in `tests/test_binary_search_context.py`, including one that documents the *old* behaviour explicitly so a future widening of the default cannot happen silently.

Full suite: **211 passed, 7 skipped**.