### PR TITLE
feat(runtime): let a caller set headers on every request the client makes

### DIFF
--- a/src/agentdebug/runtime/llm.py
+++ b/src/agentdebug/runtime/llm.py
@@ -145,6 +145,7 @@ class OpenAICompatClient:
         price_in: float = 0.0,
         price_out: float = 0.0,
         on_usage: Optional[Any] = None,
+        default_headers: Optional[Dict[str, str]] = None,
     ) -> None:
         self.base_url = base_url.rstrip('/')
         self.api_key = api_key
@@ -155,6 +156,23 @@ class OpenAICompatClient:
         self.default_max_tokens = default_max_tokens
         self.timeout = timeout
         self.extra_body = extra_body
+        #: Headers added to every request this client makes. Defaulted to None, so existing
+        #: callers and third-party subclasses are unaffected.
+        #:
+        #: WHY THIS IS NEEDED. A gateway that fronts a pool of upstream keys load-balances each
+        #: request independently, so the second call of a conversation usually lands on a
+        #: different key and re-prefills the entire prompt. Such gateways expose a session
+        #: header to pin one conversation to one key.
+        #:
+        #: Attribution is the worst case for that. The trajectory is a long shared prefix, and
+        #: a bisecting or ensemble attributor sends it several times; without a way to set the
+        #: header, every call after the first misses the cache. The effect is large and
+        #: invisible from the outside -- one gateway operator measured 4-5% cache hit rate on a
+        #: 9-key channel without the header against 82-96% with it.
+        #:
+        #: `Authorization` and `Content-Type` are applied AFTER this mapping and therefore
+        #: cannot be overridden by it, so a caller cannot accidentally break authentication.
+        self.default_headers = dict(default_headers or {})
         # USD per 1M tokens. Optional: token counts are accumulated regardless, so a
         # gateway that bills opaquely still yields usable usage data.
         self.price_in = price_in
@@ -211,6 +229,7 @@ class OpenAICompatClient:
             body.update(self.extra_body)
         url = f'{self.base_url}/chat/completions'
         headers = {
+            **self.default_headers,
             'Authorization': f'Bearer {self.api_key}',
             'Content-Type': 'application/json',
         }
@@ -297,6 +316,7 @@ class OpenAICompatClient:
             body.update(self.extra_body)
         url = f'{self.base_url}/chat/completions'
         headers = {
+            **self.default_headers,
             'Authorization': f'Bearer {self.api_key}',
             'Content-Type': 'application/json',
         }
@@ -335,6 +355,7 @@ class OpenAICompatClient:
             return []
         url = f'{self.base_url}/embeddings'
         headers = {
+            **self.default_headers,
             'Authorization': f'Bearer {self.api_key}',
             'Content-Type': 'application/json',
         }

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -1,0 +1,87 @@
+"""`OpenAICompatClient(default_headers=...)` — sent on every request, never able to break auth.
+
+Attribution is the worst case for gateway prompt caching: the trajectory is a long shared
+prefix, and a bisecting or ensemble attributor sends it several times. A gateway fronting a pool
+of upstream keys load-balances each request independently, so without a session header the
+second call lands on a different key and re-prefills everything. There was previously no way to
+set such a header on this client.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from agentdebug.runtime.llm import OpenAICompatClient
+
+
+class _Recorder:
+    """Captures the headers of every httpx.post the client makes."""
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    def post(self, url: str, headers=None, json=None, timeout=None):  # noqa: A002
+        self.calls.append({'url': url, 'headers': dict(headers or {})})
+
+        class _Resp:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {
+                    'choices': [{'message': {'content': 'ok'}, 'finish_reason': 'stop'}],
+                    'usage': {'prompt_tokens': 1, 'completion_tokens': 1},
+                }
+
+            @staticmethod
+            def raise_for_status():
+                return None
+
+            text = ''
+
+        return _Resp()
+
+
+def _client(**kw) -> OpenAICompatClient:
+    return OpenAICompatClient(base_url='https://example.invalid/v1', api_key='k',
+                              model='m', **kw)
+
+
+def test_default_is_none_so_existing_callers_are_unaffected():
+    assert _client().default_headers == {}
+
+
+def test_a_supplied_header_reaches_the_request(monkeypatch):
+    rec = _Recorder()
+    monkeypatch.setattr('agentdebug.runtime.llm.httpx', rec)
+    c = _client(default_headers={'X-Llmhub-Session': 'trace-abc'})
+    c.complete([{'role': 'user', 'content': 'hi'}])
+    assert rec.calls, 'no request was made'
+    assert rec.calls[0]['headers']['X-Llmhub-Session'] == 'trace-abc'
+
+
+def test_auth_and_content_type_cannot_be_overridden(monkeypatch):
+    """A caller must not be able to break authentication with a typo in a header name."""
+    rec = _Recorder()
+    monkeypatch.setattr('agentdebug.runtime.llm.httpx', rec)
+    c = _client(default_headers={'Authorization': 'Bearer WRONG',
+                                 'Content-Type': 'text/plain'})
+    c.complete([{'role': 'user', 'content': 'hi'}])
+    h = rec.calls[0]['headers']
+    assert h['Authorization'] == 'Bearer k'
+    assert h['Content-Type'] == 'application/json'
+
+
+def test_the_mapping_is_copied_not_aliased():
+    """Mutating the caller's dict afterwards must not change what the client sends."""
+    supplied = {'X-Llmhub-Session': 'one'}
+    c = _client(default_headers=supplied)
+    supplied['X-Llmhub-Session'] = 'two'
+    assert c.default_headers['X-Llmhub-Session'] == 'one'
+
+
+@pytest.mark.parametrize('value', [{}, None])
+def test_empty_and_none_are_equivalent(value):
+    assert _client(default_headers=value).default_headers == {}


### PR DESCRIPTION
Carries one commit that never reached `main` while PRs #4, #5 and #6 did.

## What it does

Lets a caller attach headers to every request the runtime's LLM client makes, rather than only to a
single call. 21 lines in `src/agentdebug/runtime/llm.py`, plus `tests/test_default_headers.py`.

## Why it is needed downstream

AgentErrorData routes every diagnosis through an internal gateway that requires per-run headers for
session stickiness. Without this the headers can only be set per call, so a multi-call attributor
loses stickiness partway through a diagnosis and the gateway may route later calls to a cold
session.

## Scope

Cherry-picked onto current `main`, so the diff is only this feature. No upstream work is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)