### PR TITLE
bump: version 0.3.1 → 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentdebugx"
-version = "0.3.1"
+version = "0.4.0"
 description = "Portable error analysis, tracing, and recovery framework for agentic AI systems. Import as `agentdebug`."
 authors = ["ULab @ UIUC <ulab@illinois.edu>"]
 license = "MIT"

--- a/src/agentdebug/__init__.py
+++ b/src/agentdebug/__init__.py
@@ -291,7 +291,7 @@ __all__ = [
     'write_converted_trajectory',
 ]
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'
 
 _COMPAT_MODULE_ALIASES = {
     'agentdebug.models': _core_models_mod,


### PR DESCRIPTION
Releases everything merged since 0.3.1 (PyPI 2026-07-17) so that `pip install agentdebugx` matches main:

- TrajDebug evidence-grounded detection and state-aware attribution as sub-methods (#10); per-step Stage B detection; graded Stage A context with swappable root selection; quote verification against what the model was shown, with an opt-in similarity floor.
- Taxonomy: the observation family.
- Runtime: opt-in retry with backoff in `OpenAICompatClient`; raised budgets for reasoning models.
- Ingest: TrajDebug unified trajectory JSON; deterministic event ids; secret redaction in host transcripts.
- Capture and integrations: native Claude and Codex plugins, the unified run workflow (#11).

Version bumped in `pyproject.toml` and `src/agentdebug/__init__.py` (the two `version_files` in the commitizen config). Wheel and sdist build from this commit and pass `twine check`. Publication to PyPI follows the merge and the `v0.4.0` tag.

Consumer: AgentErrorData pins `agentdebugx>=0.4.0` as its analysis stack (owner directive 2026-09-04).