### PR TITLE
detect: region-typed evidence location and finding grounding

### DIFF
--- a/src/agentdebug/diagnose/detect/README.md
+++ b/src/agentdebug/diagnose/detect/README.md
@@ -64,6 +64,64 @@ still fails.
 
 Adapted from TrajDebug Stage B (THU-KEG/TrajDebug, MIT).
 
+### Where a quote came from
+
+`quote_verified` is a boolean, which is what a detector needs to keep or drop
+a finding. A consumer that stores findings needs to know *where* a quote was
+found, because position is evidence too: a verbatim quote of the grader's
+verdict at the last event does not support a diagnosis of step 4.
+
+`locate_quote(trajectory, quote, anchor=None, shown=None)` returns a
+`QuoteLocation`:
+
+- `rung` -- `exact` (verbatim substring of the stored field), `normalized`
+  (after the same normalisation `verify_finding_quotes` applies, plus removal
+  of the renderer's `[step 3] event_id=... output=` framing and one pair of
+  wrapping quotation marks), `anchored` (the text was found nowhere but the
+  quote or the caller named an event id that exists -- a pointer, not a
+  transcription), or `unresolvable`
+- `region` -- `event`, `shown` (the text a detector rendered for an event),
+  `goal`, or `none`; with `event_id`, `event_index`, `step_index`,
+  `event_type` and `field` (`input` / `output` / `error`) for an event
+- `span` and `text` -- character offsets into the stored field (as `str`, or
+  `repr` for a non-string value), the `shown` text, or the goal, and the slice
+  they cover. Offsets are into the raw field even when the match was made after
+  unescaping, so `event.output[start:end]` is the cited text
+- `anchor` and `anchor_status` -- `not_declared`, `resolved`, `unknown_event`
+  (an id the trajectory does not contain), or `elsewhere` (a real id whose
+  event does not contain the text: a mislabelling, not a fabrication)
+- `grounded` -- `rung` is `exact` or `normalized` and `region` is `event` or
+  `shown`. A goal quote is faithful and grounds nothing about the trajectory;
+  a real pointer locates an event but cannot be checked by string search.
+
+Rungs are tried strictest first; within a rung the anchor's event is searched
+before the others, then the remaining events in order, then the goal.
+
+`resolve_anchor(trajectory, event_id)` returns the event an id names, by exact
+match, or `None`.
+
+`grounds_trajectory(findings, trajectory, shown=None)` locates the
+`wrong_content_quote` (anchored on the blamed event) and `reference_quote` of
+each finding and places each relative to the blamed event: `position` is
+`before` / `at` / `after`, and `at_or_before_blame` is the question a consumer
+asks -- was this text in front of the agent when it acted? `FindingGrounding.
+grounded` is `None` for a finding with no quotes (as `quote_verified` is),
+and otherwise requires every quote to be located under a grounding rung, none
+to come from after the blame, and the wrong-content quote to sit at it.
+`annotate_evidence_regions(findings, trajectory)` writes that as JSON into
+`finding.metadata['evidence_regions']`, next to `quote_verified`.
+
+```python
+from agentdebug.diagnose.detect.evidence import locate_quote, grounds_trajectory
+
+loc = locate_quote(trajectory, 'you see a cd 3')
+loc.rung, loc.event_id, loc.field, loc.span   # 'exact', 'evt_...', 'output', (17, 31)
+
+for g in grounds_trajectory(report.findings, trajectory):
+    for q in g.quotes:
+        print(g.finding_id, q.role, q.location.rung, q.position, q.at_or_before_blame)
+```
+
 ## Context budget
 
 Both LLM detectors render the trajectory by clipping each event to a fixed

--- a/src/agentdebug/diagnose/detect/evidence.py
+++ b/src/agentdebug/diagnose/detect/evidence.py
@@ -38,7 +38,8 @@ Adapted from the evidence-grounding requirement in TrajDebug
 from __future__ import annotations
 
 import re
-from typing import Iterable, List, Mapping, Optional, Sequence
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from agentdebug.schema import (
     AgentEvent,
@@ -52,6 +53,14 @@ __all__ = [
     'verify_finding_quotes',
     'annotate_quote_verification',
     'quote_verification_summary',
+    'QuoteLocation',
+    'QuoteGrounding',
+    'FindingGrounding',
+    'locate_quote',
+    'resolve_anchor',
+    'grounds_trajectory',
+    'annotate_evidence_regions',
+    'GROUNDING_RUNGS',
 ]
 
 _WS = re.compile(r'\s+')
@@ -358,3 +367,574 @@ def quote_verification_summary(findings: Iterable[FailureFinding]) -> dict:
         else:
             summary['unchecked'] += 1
     return summary
+
+
+# ---------------------------------------------------------------------------
+# Region-typed location
+#
+# :func:`verify_finding_quotes` answers "does the quote occur where the finding
+# says it does" with a boolean, which is what a detector needs to keep or drop
+# a finding. A consumer that *stores* findings needs more than the boolean. It
+# needs to know where the quote was found -- which event, which field of it,
+# at which character span -- so that a claim about the trajectory can be
+# checked against the position of its evidence: a verbatim quote of the
+# grader's verdict at the last event does not support a diagnosis of step 4.
+# And when the quote cannot be found it needs to know whether the finding at
+# least pointed at a real event, because an invented event id and a paraphrase
+# of a real event are different defects with different fixes.
+#
+# Nothing below changes what :func:`verify_finding_quotes` accepts. The
+# ``normalized`` rung applies the same normalisation, so a quote that verifies
+# also locates; the extra information is *where*.
+# ---------------------------------------------------------------------------
+
+#: Rungs, strictest first. A quote is credited to the first rung that locates it.
+#: ``exact`` -- verbatim substring of the stored field.
+#: ``normalized`` -- substring after the normalisation ``verify_finding_quotes``
+#: applies (JSON escapes, whitespace, a trailing truncation marker) and after
+#: removing the framing a renderer puts around an event -- ``[step 3]``,
+#: ``event_id=evt_...``, ``output=`` -- which a model copying a line copies too.
+#: ``anchored`` -- the text was found nowhere, but the quote (or the caller)
+#: named an event id that exists. A pointer, not a transcription.
+#: ``unresolvable`` -- neither the text nor an anchor places it.
+RUNG_EXACT = 'exact'
+RUNG_NORMALIZED = 'normalized'
+RUNG_ANCHORED = 'anchored'
+RUNG_UNRESOLVABLE = 'unresolvable'
+#: Rungs under which the quoted text is demonstrably present. ``anchored`` is
+#: deliberately excluded: a real pointer with unverifiable text locates an
+#: event, but it does not let a reader falsify the quote by string search.
+GROUNDING_RUNGS = frozenset({RUNG_EXACT, RUNG_NORMALIZED})
+
+#: Where a quote was found. ``event`` is a stored field of an event; ``shown``
+#: is the text a detector rendered for an event (see ``verify_finding_quotes``
+#: for why that is a permitted, weaker, haystack); ``goal`` is the task
+#: statement, which is not an event and grounds nothing about what the agent
+#: did.
+REGION_EVENT = 'event'
+REGION_SHOWN = 'shown'
+REGION_GOAL = 'goal'
+REGION_NONE = 'none'
+
+#: What the declared anchor turned out to be, relative to where the text was
+#: found. ``resolved`` and ``elsewhere`` both mean the event exists; they
+#: differ in whether the quote is in it. A real id carrying another event's
+#: text is a mislabelling, not a fabrication, and the two need different fixes.
+ANCHOR_NOT_DECLARED = 'not_declared'
+ANCHOR_RESOLVED = 'resolved'
+ANCHOR_UNKNOWN_EVENT = 'unknown_event'
+ANCHOR_ELSEWHERE = 'elsewhere'
+
+_EVENT_FIELDS = ('input', 'output', 'error')
+
+#: Framing a renderer puts around an event, or a model adds when reproducing a
+#: line. Anchored on the start of the quote, so only a leading frame is
+#: removed and the quoted content itself must still match. The event-id forms
+#: are the ones the built-in renderers print (``event_id=evt_x``) and the ones
+#: models write when asked to cite (``evt_x: ...``, ``(evt_x) ...``,
+#: ``[evt_x][agent][kind] ...``).
+_FRAME = re.compile(
+    r'^\s*'
+    r'(?:\[step\s+\d+\]|step\s+\d+\s*[:\-])?\s*'
+    r'(?:\[(?P<bracket>evt_\w+)\](?:\[[^\]]*\]){0,2}'
+    r'|\((?P<paren>evt_\w+)\)'
+    r'|event_id=(?P<kw>[^\s,;:]+)'
+    r'|(?P<colon>evt_\w+)\s*[:\-])?\s*'
+    r'(?:(?:type|agent)=\S+\s*)*'
+    r'(?:(?:input|output|error|metadata)\s*[:=])?\s*',
+    re.IGNORECASE,
+)
+_QUOTE_PAIRS = (('"', '"'), ("'", "'"), ('`', '`'), ('“', '”'), ('‘', '’'))
+
+
+_BARE_ID = re.compile(r'^(?P<id>evt_[A-Za-z0-9_-]+)(?:\s*:\s*(?P<rest>.*))?$', re.S)
+
+
+def _split_frame(quote: str) -> Tuple[Optional[str], str]:
+    """Return ``(declared event id, content)`` for a possibly framed quote.
+
+    One pair of wrapping quotation marks is removed as well, because a model
+    that writes ``step 3: "text"`` has quoted ``text``. Only a matching pair
+    is removed, so a quote that legitimately begins with a quotation mark --
+    a JSON fragment such as ``"answer": 5`` -- keeps it.
+    """
+    match = _FRAME.match(quote)
+    declared: Optional[str] = None
+    inner = quote
+    if match:
+        declared = (
+            match.group('bracket') or match.group('paren')
+            or match.group('kw') or match.group('colon')
+        )
+        inner = quote[match.end():]
+    if declared is None:
+        # `_FRAME` is entirely optional and so always matches; a bare event id
+        # (`evt_x`) or `evt_x: text` that its alternatives do not cover is
+        # still a declared anchor.
+        bare = _BARE_ID.match(inner.strip())
+        if bare:
+            declared = bare.group('id')
+            inner = bare.group('rest') or ''
+    inner = inner.strip()
+    for open_, close in _QUOTE_PAIRS:
+        if len(inner) >= 2 and inner.startswith(open_) and inner.endswith(close):
+            inner = inner[1:-1].strip()
+            break
+    return declared, inner
+
+
+def _norm_with_map(text: str) -> Tuple[str, List[Tuple[int, int]]]:
+    """:func:`_norm`, plus for each output character its ``(start, end)`` in ``text``.
+
+    Kept step-for-step equivalent to ``_norm`` -- the same sequential escape
+    replacements, then whitespace runs collapsed to one space, then a strip --
+    so that a needle found in the mapped text is found by ``_norm`` too. The
+    map is what lets a match made after normalisation report a span into the
+    raw field, which is the only form a span is useful in: a consumer slices
+    the stored value, not our scratch string.
+    """
+    chars = list(text)
+    spans = [(i, i + 1) for i in range(len(text))]
+    for seq, char in _ESCAPES:
+        chars, spans = _replace_with_map(chars, spans, seq, char)
+    out_chars: List[str] = []
+    out_spans: List[Tuple[int, int]] = []
+    i = 0
+    while i < len(chars):
+        if chars[i].isspace():
+            j = i
+            while j < len(chars) and chars[j].isspace():
+                j += 1
+            out_chars.append(' ')
+            out_spans.append((spans[i][0], spans[j - 1][1]))
+            i = j
+        else:
+            out_chars.append(chars[i])
+            out_spans.append(spans[i])
+            i += 1
+    while out_chars and out_chars[0] == ' ':
+        out_chars.pop(0)
+        out_spans.pop(0)
+    while out_chars and out_chars[-1] == ' ':
+        out_chars.pop()
+        out_spans.pop()
+    return ''.join(out_chars), out_spans
+
+
+def _replace_with_map(
+    chars: List[str], spans: List[Tuple[int, int]], seq: str, char: str
+) -> Tuple[List[str], List[Tuple[int, int]]]:
+    """``str.replace`` over a character list, carrying source spans along."""
+    n = len(seq)
+    out_chars: List[str] = []
+    out_spans: List[Tuple[int, int]] = []
+    i = 0
+    while i < len(chars):
+        if chars[i] == seq[0] and ''.join(chars[i:i + n]) == seq:
+            out_chars.append(char)
+            out_spans.append((spans[i][0], spans[i + n - 1][1]))
+            i += n
+        else:
+            out_chars.append(chars[i])
+            out_spans.append(spans[i])
+            i += 1
+    return out_chars, out_spans
+
+
+def _field_text(event: AgentEvent, field: str) -> str:
+    """The string a field is searched as. Mirrors ``_event_text``: non-strings by repr."""
+    value = getattr(event, field, None)
+    if value is None:
+        return ''
+    if isinstance(value, str):
+        return value
+    return repr(value)
+
+
+def _event_type_value(event: AgentEvent) -> str:
+    return str(getattr(event.event_type, 'value', event.event_type))
+
+
+@dataclass(frozen=True)
+class QuoteLocation:
+    """Where a quote was found, and how.
+
+    ``span`` indexes the text named by ``region`` and ``field``: the stored
+    field (as ``str``, or ``repr`` for a non-string value), the ``shown`` text
+    for that event, or the goal. ``text`` is that slice, so a reader can
+    confirm the span without recomputing anything. Both are ``None`` for the
+    ``anchored`` and ``unresolvable`` rungs, where no text was located.
+    """
+
+    rung: str
+    region: str
+    event_id: Optional[str] = None
+    event_index: Optional[int] = None
+    step_index: Optional[int] = None
+    event_type: Optional[str] = None
+    field: Optional[str] = None
+    span: Optional[Tuple[int, int]] = None
+    text: Optional[str] = None
+    anchor: Optional[str] = None
+    anchor_status: str = ANCHOR_NOT_DECLARED
+
+    @property
+    def grounded(self) -> bool:
+        """Is the text demonstrably present in something the agent produced or saw?
+
+        Both halves matter. A quote located in the goal is faithful and
+        grounds nothing about the trajectory; a real pointer with text found
+        nowhere locates an event but cannot be checked by string search.
+        """
+        return self.rung in GROUNDING_RUNGS and self.region in (REGION_EVENT, REGION_SHOWN)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'rung': self.rung,
+            'region': self.region,
+            'event_id': self.event_id,
+            'event_index': self.event_index,
+            'step_index': self.step_index,
+            'event_type': self.event_type,
+            'field': self.field,
+            'span': list(self.span) if self.span is not None else None,
+            'text': self.text,
+            'anchor': self.anchor,
+            'anchor_status': self.anchor_status,
+            'grounded': self.grounded,
+        }
+
+
+def resolve_anchor(trajectory: AgentTrajectory, event_id: Optional[str]) -> Optional[AgentEvent]:
+    """The event an id names, or ``None``.
+
+    Exact match only. Ids come from the trajectory, and a detector is asked to
+    copy them; an id that differs in any character is one the detector did
+    not copy, which is the case this exists to expose.
+    """
+    if not event_id:
+        return None
+    for event in trajectory.events:
+        if event.event_id == event_id:
+            return event
+    return None
+
+
+def locate_quote(
+    trajectory: AgentTrajectory,
+    quote: str,
+    *,
+    anchor: Optional[str] = None,
+    shown: Optional[Mapping[str, str]] = None,
+) -> QuoteLocation:
+    """Find where ``quote`` occurs in what the detector was given.
+
+    Rungs are tried strictest first, and within a rung the anchor's event is
+    searched before the others, then the remaining events in trajectory
+    order, then the goal. So a quote present in both its anchor and a later
+    event is credited to the anchor, and one present in both an event and the
+    goal is credited to the event.
+
+    ``anchor`` is the event id the caller says the quote came from -- for a
+    ``wrong_content_quote`` that is the blamed event. When the caller passes
+    none, an id embedded in the quote itself (``evt_x: ...``) is used. Either
+    way the outcome is reported in ``anchor_status`` rather than folded into
+    the rung, because "the text is real but the id is wrong" is a different
+    finding from "the text is invented".
+
+    ``shown`` maps event id to the text a detector rendered for that event,
+    exactly as in :func:`verify_finding_quotes`; a quote found only there is
+    reported with ``region='shown'``.
+    """
+    events = list(trajectory.events)
+    declared, inner = _split_frame(quote or '')
+    anchor_id = anchor or declared
+    anchor_event = resolve_anchor(trajectory, anchor_id)
+    if anchor_id and anchor_event is None:
+        anchor_state = ANCHOR_UNKNOWN_EVENT
+    elif anchor_id:
+        anchor_state = ANCHOR_RESOLVED
+    else:
+        anchor_state = ANCHOR_NOT_DECLARED
+
+    def finish(loc: QuoteLocation) -> QuoteLocation:
+        status = anchor_state
+        if anchor_event is not None and loc.event_id != anchor_event.event_id:
+            status = ANCHOR_ELSEWHERE
+        return QuoteLocation(
+            rung=loc.rung, region=loc.region, event_id=loc.event_id,
+            event_index=loc.event_index, step_index=loc.step_index,
+            event_type=loc.event_type, field=loc.field, span=loc.span,
+            text=loc.text, anchor=anchor_id, anchor_status=status,
+        )
+
+    if not (quote or '').strip():
+        return finish(QuoteLocation(rung=RUNG_UNRESOLVABLE, region=REGION_NONE))
+
+    order = list(range(len(events)))
+    if anchor_event is not None:
+        order.sort(key=lambda i: events[i] is not anchor_event)
+
+    # Rung 1: the quote as given, verbatim.
+    exact = quote
+    for i in order:
+        found = _find_in_event(events[i], i, exact, shown, normalized=False)
+        if found is not None:
+            return finish(found)
+    if trajectory.goal and exact in trajectory.goal:
+        start = trajectory.goal.index(exact)
+        return finish(QuoteLocation(
+            rung=RUNG_EXACT, region=REGION_GOAL, span=(start, start + len(exact)),
+            text=exact,
+        ))
+    if inner and inner != exact:
+        for i in order:
+            found = _find_in_event(events[i], i, inner, shown, normalized=False)
+            if found is not None:
+                return finish(found)
+        if trajectory.goal and inner in trajectory.goal:
+            start = trajectory.goal.index(inner)
+            return finish(QuoteLocation(
+                rung=RUNG_EXACT, region=REGION_GOAL, span=(start, start + len(inner)),
+                text=inner,
+            ))
+
+    # Rung 2: after the normalisation `verify_finding_quotes` applies, with the
+    # quote's own framing removed. The unframed form is tried first so that a
+    # quote copied from a rendering that includes the frame still resolves
+    # against `shown`.
+    needles: List[str] = []
+    for candidate in (_norm_quote(quote), _norm_quote(inner)):
+        if candidate and candidate not in needles:
+            needles.append(candidate)
+    for needle in needles:
+        for i in order:
+            found = _find_in_event(events[i], i, needle, shown, normalized=True)
+            if found is not None:
+                return finish(found)
+        if trajectory.goal:
+            span = _find_normalized(needle, trajectory.goal)
+            if span is not None:
+                return finish(QuoteLocation(
+                    rung=RUNG_NORMALIZED, region=REGION_GOAL, span=span,
+                    text=trajectory.goal[span[0]:span[1]],
+                ))
+
+    # Rung 3: no text located; a real anchor still places the claim at an event.
+    if anchor_event is not None:
+        index = events.index(anchor_event)
+        return finish(QuoteLocation(
+            rung=RUNG_ANCHORED, region=REGION_EVENT, event_id=anchor_event.event_id,
+            event_index=index, step_index=anchor_event.step_index,
+            event_type=_event_type_value(anchor_event),
+        ))
+
+    return finish(QuoteLocation(rung=RUNG_UNRESOLVABLE, region=REGION_NONE))
+
+
+def _find_normalized(needle: str, haystack: str) -> Optional[Tuple[int, int]]:
+    """Span of ``needle`` in ``haystack`` after ``_norm``, mapped back to raw offsets.
+
+    The regex-based ``_norm`` is the fast pre-check; the offset map is built
+    only for a haystack that contains the needle.
+    """
+    if not needle or needle not in _norm(haystack):
+        return None
+    mapped, spans = _norm_with_map(haystack)
+    start = mapped.find(needle)
+    if start < 0:  # pragma: no cover - the map is equivalent to _norm by construction
+        return None
+    end = start + len(needle)
+    return spans[start][0], spans[end - 1][1]
+
+
+def _find_in_event(
+    event: AgentEvent,
+    index: int,
+    needle: str,
+    shown: Optional[Mapping[str, str]],
+    normalized: bool,
+) -> Optional[QuoteLocation]:
+    rung = RUNG_NORMALIZED if normalized else RUNG_EXACT
+    for field in _EVENT_FIELDS:
+        text = _field_text(event, field)
+        if not text:
+            continue
+        span = _find_normalized(needle, text) if normalized else _find_exact(needle, text)
+        if span is not None:
+            return QuoteLocation(
+                rung=rung, region=REGION_EVENT, event_id=event.event_id,
+                event_index=index, step_index=event.step_index,
+                event_type=_event_type_value(event), field=field, span=span,
+                text=text[span[0]:span[1]],
+            )
+    rendered = (shown or {}).get(event.event_id)
+    if rendered:
+        span = _find_normalized(needle, rendered) if normalized else _find_exact(needle, rendered)
+        if span is not None:
+            return QuoteLocation(
+                rung=rung, region=REGION_SHOWN, event_id=event.event_id,
+                event_index=index, step_index=event.step_index,
+                event_type=_event_type_value(event), span=span,
+                text=rendered[span[0]:span[1]],
+            )
+    return None
+
+
+def _find_exact(needle: str, haystack: str) -> Optional[Tuple[int, int]]:
+    start = haystack.find(needle)
+    if start < 0:
+        return None
+    return start, start + len(needle)
+
+
+@dataclass(frozen=True)
+class QuoteGrounding:
+    """One quote of a finding, located and placed relative to the blamed event.
+
+    ``position`` is ``before`` / ``at`` / ``after`` the blamed event, or
+    ``None`` when either side is unknown. ``at_or_before_blame`` is the
+    question a consumer of the finding actually asks: was this text in front
+    of the agent when it acted? Evidence from a later event is hindsight, and
+    a diagnosis resting on it is reasoning from the outcome rather than from
+    what was visible.
+    """
+
+    role: str
+    quote: str
+    location: QuoteLocation
+    position: Optional[str] = None
+
+    @property
+    def at_or_before_blame(self) -> Optional[bool]:
+        if self.position is None:
+            return None
+        return self.position in ('before', 'at')
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'role': self.role,
+            'quote': self.quote,
+            'location': self.location.to_dict(),
+            'position': self.position,
+            'at_or_before_blame': self.at_or_before_blame,
+        }
+
+
+@dataclass(frozen=True)
+class FindingGrounding:
+    """Per-finding resolution of its quotes against the trajectory."""
+
+    finding_id: str
+    blamed_event_id: Optional[str]
+    blamed_event_index: Optional[int]
+    blamed_step_index: Optional[int]
+    quotes: Tuple[QuoteGrounding, ...]
+
+    @property
+    def grounded(self) -> Optional[bool]:
+        """``None`` when the finding carries no quotes, matching ``quote_verified``.
+
+        Otherwise every quote must be located under a grounding rung, none may
+        come from after the blamed event, and the wrong-content quote -- the
+        claim about the blamed step itself -- must be in that step.
+        """
+        if not self.quotes:
+            return None
+        for q in self.quotes:
+            if not q.location.grounded or not q.at_or_before_blame:
+                return False
+            if q.role == 'wrong_content' and q.position != 'at':
+                return False
+        return True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'finding_id': self.finding_id,
+            'blamed_event_id': self.blamed_event_id,
+            'blamed_event_index': self.blamed_event_index,
+            'blamed_step_index': self.blamed_step_index,
+            'quotes': [q.to_dict() for q in self.quotes],
+            'grounded': self.grounded,
+        }
+
+
+def _position(
+    location: QuoteLocation, blamed: Optional[AgentEvent], events: Sequence[AgentEvent]
+) -> Optional[str]:
+    """Where a located quote sits relative to the blamed event.
+
+    Compared by ``step_index`` when both carry one, since several events
+    share a step (the agent's call and the tool's result) and "at the blamed
+    step" has to cover all of them; by position in the trajectory otherwise.
+    """
+    if blamed is None or location.event_index is None:
+        return None
+    located_step = location.step_index
+    if located_step is not None and blamed.step_index is not None:
+        a, b = located_step, blamed.step_index
+    else:
+        a, b = location.event_index, events.index(blamed)
+    if a < b:
+        return 'before'
+    if a == b:
+        return 'at'
+    return 'after'
+
+
+def grounds_trajectory(
+    findings: Iterable[FailureFinding],
+    trajectory: AgentTrajectory,
+    shown: Optional[Mapping[str, str]] = None,
+) -> List[FindingGrounding]:
+    """Locate every quote of every finding and place it relative to the blame.
+
+    The wrong-content quote is located with the blamed event as its anchor,
+    since that is where the finding says it came from; the reference quote
+    carries no anchor unless it embeds one. Findings with neither quote get an
+    empty ``quotes`` tuple and ``grounded=None`` -- the rule packs have no
+    claim to quote, and that is not a failure to ground.
+    """
+    events = list(trajectory.events)
+    out: List[FindingGrounding] = []
+    for finding in findings:
+        blamed = _blamed_event(finding, events)
+        quotes: List[QuoteGrounding] = []
+        for role, quote, anchor in (
+            ('wrong_content', finding.wrong_content_quote,
+             blamed.event_id if blamed is not None else None),
+            ('reference', finding.reference_quote, None),
+        ):
+            if not quote:
+                continue
+            location = locate_quote(trajectory, quote, anchor=anchor, shown=shown)
+            quotes.append(QuoteGrounding(
+                role=role, quote=quote, location=location,
+                position=_position(location, blamed, events),
+            ))
+        out.append(FindingGrounding(
+            finding_id=finding.finding_id,
+            blamed_event_id=blamed.event_id if blamed is not None else None,
+            blamed_event_index=events.index(blamed) if blamed is not None else None,
+            blamed_step_index=blamed.step_index if blamed is not None else None,
+            quotes=tuple(quotes),
+        ))
+    return out
+
+
+def annotate_evidence_regions(
+    findings: Iterable[FailureFinding],
+    trajectory: AgentTrajectory,
+    shown: Optional[Mapping[str, str]] = None,
+) -> List[FailureFinding]:
+    """Record each finding's grounding in ``metadata['evidence_regions']``.
+
+    Sits next to ``quote_verified``: the boolean says whether the quotes
+    resolve, this says where, so a consumer storing the finding can later
+    check that its evidence precedes the step it blames without re-running
+    the detector.
+    """
+    annotated = list(findings)
+    for finding, grounding in zip(annotated, grounds_trajectory(annotated, trajectory, shown)):
+        finding.metadata['evidence_regions'] = grounding.to_dict()
+    return annotated

--- a/tests/test_detect_evidence_regions.py
+++ b/tests/test_detect_evidence_regions.py
@@ -1,0 +1,387 @@
+"""Contracts for region-typed quote location.
+
+``verify_finding_quotes`` says whether a quote resolves. These functions say
+where, and the tests that matter are the ones a boolean cannot express: the
+rung a quote lands on, the event and field it came from, a span that slices
+back to the same text, an anchor that names a real event but the wrong one,
+and a verbatim quote taken from *after* the step it is offered as evidence
+for.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+import pytest
+
+from agentdebug.diagnose.detect.evidence import (
+    ANCHOR_ELSEWHERE,
+    ANCHOR_NOT_DECLARED,
+    ANCHOR_RESOLVED,
+    ANCHOR_UNKNOWN_EVENT,
+    GROUNDING_RUNGS,
+    RUNG_ANCHORED,
+    RUNG_EXACT,
+    RUNG_NORMALIZED,
+    RUNG_UNRESOLVABLE,
+    _norm,
+    _norm_with_map,
+    annotate_evidence_regions,
+    grounds_trajectory,
+    locate_quote,
+    resolve_anchor,
+    verify_finding_quotes,
+)
+from agentdebug.schema import (
+    AgentEvent,
+    AgentTrajectory,
+    ConflictAxis,
+    EventType,
+    FailureFinding,
+    FailureMode,
+)
+
+MODE = FailureMode(
+    mode_id='observation.misread',
+    name='Observation misread',
+    family='observation',
+    description='The agent misread environment or tool output.',
+)
+
+PLAN = 'First I will survey the room, then take the book.'
+DESK = 'On the desk 1, you see a cd 3, a cellphone 1, and a pen 1.'
+CLAIM = 'The desk has a desklamp, so I will examine it.'
+VERDICT = 'Task failed: the book was never taken.'
+GOAL = 'Look at the book under the desklamp.'
+
+
+@pytest.fixture
+def trajectory() -> AgentTrajectory:
+    traj = AgentTrajectory(trace_id='t1', goal=GOAL)
+    traj.add_event(AgentEvent(
+        event_id='evt_plan', trace_id='t1', agent_name='agent',
+        event_type=EventType.PLAN, step_index=0, output=PLAN,
+    ))
+    traj.add_event(AgentEvent(
+        event_id='evt_desk', trace_id='t1', agent_name='env',
+        event_type=EventType.TOOL_RESULT, step_index=1, output=DESK,
+    ))
+    traj.add_event(AgentEvent(
+        event_id='evt_claim', trace_id='t1', agent_name='agent',
+        event_type=EventType.AGENT_STEP, step_index=2, output=CLAIM,
+    ))
+    traj.add_event(AgentEvent(
+        event_id='evt_verdict', trace_id='t1', agent_name='env',
+        event_type=EventType.OBSERVATION, step_index=3, output=VERDICT,
+    ))
+    return traj
+
+
+def _finding(step: Optional[int] = 2, **kwargs: Any) -> FailureFinding:
+    return FailureFinding(failure_mode=MODE, step_index=step, **kwargs)
+
+
+class TestEveryRung:
+    def test_exact_reports_event_field_and_a_span_that_slices_back(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        loc = locate_quote(trajectory, 'you see a cd 3')
+        assert loc.rung == RUNG_EXACT
+        assert loc.region == 'event'
+        assert (loc.event_id, loc.event_index, loc.step_index) == ('evt_desk', 1, 1)
+        assert loc.event_type == 'tool.result', 'the role a consumer maps to observation/tool result'
+        assert loc.field == 'output'
+        assert loc.span is not None and DESK[loc.span[0]:loc.span[1]] == loc.text == 'you see a cd 3'
+        assert loc.grounded
+        assert loc.anchor_status == ANCHOR_NOT_DECLARED
+
+    def test_normalized_forgives_reflow_and_the_renderer_frame(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        """A model copying a rendered line copies its framing. That is ours, not content."""
+        loc = locate_quote(
+            trajectory,
+            '[step 1] event_id=evt_desk type=tool.result agent=env output="you  see a\n cd 3"',
+        )
+        assert loc.rung == RUNG_NORMALIZED
+        assert loc.event_id == 'evt_desk' and loc.field == 'output'
+        assert loc.span is not None and DESK[loc.span[0]:loc.span[1]] == 'you see a cd 3'
+        assert loc.anchor == 'evt_desk', 'the id in the frame is the declared anchor'
+        assert loc.anchor_status == ANCHOR_RESOLVED
+        assert loc.grounded
+
+    def test_anchored_is_a_real_pointer_with_no_locatable_text(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        """The event exists; the text does not. A pointer locates, it does not ground."""
+        loc = locate_quote(trajectory, 'evt_desk: the agent looked at the desk')
+        assert loc.rung == RUNG_ANCHORED
+        assert loc.region == 'event'
+        assert loc.event_id == 'evt_desk' and loc.event_index == 1
+        assert loc.span is None and loc.text is None
+        assert loc.anchor_status == ANCHOR_RESOLVED
+        assert not loc.grounded
+        assert RUNG_ANCHORED not in GROUNDING_RUNGS
+
+        pointer_only = locate_quote(trajectory, 'evt_desk')
+        assert pointer_only.rung == RUNG_ANCHORED
+
+    def test_unresolvable_when_nothing_places_it(self, trajectory: AgentTrajectory) -> None:
+        loc = locate_quote(trajectory, 'the agent deleted the production database')
+        assert loc.rung == RUNG_UNRESOLVABLE
+        assert loc.region == 'none'
+        assert loc.event_id is None and loc.span is None
+        assert not loc.grounded
+
+    @pytest.mark.parametrize('quote', ['', '   ', None])
+    def test_an_empty_quote_is_unresolvable_not_an_error(
+        self, trajectory: AgentTrajectory, quote: Any
+    ) -> None:
+        assert locate_quote(trajectory, quote).rung == RUNG_UNRESOLVABLE
+
+
+class TestAnchors:
+    def test_resolve_anchor_is_exact_match_only(self, trajectory: AgentTrajectory) -> None:
+        event = resolve_anchor(trajectory, 'evt_desk')
+        assert event is not None and event.output == DESK
+        assert resolve_anchor(trajectory, 'evt_des') is None
+        assert resolve_anchor(trajectory, 'EVT_DESK') is None
+        assert resolve_anchor(trajectory, None) is None
+        assert resolve_anchor(trajectory, '') is None
+
+    def test_an_invented_id_is_reported_as_such(self, trajectory: AgentTrajectory) -> None:
+        loc = locate_quote(trajectory, 'evt_zzz999: you see a cd 3')
+        assert loc.rung == RUNG_EXACT, 'the text is real'
+        assert loc.event_id == 'evt_desk'
+        assert loc.anchor == 'evt_zzz999'
+        assert loc.anchor_status == ANCHOR_UNKNOWN_EVENT
+
+        nowhere = locate_quote(trajectory, 'evt_zzz999: anything at all')
+        assert nowhere.rung == RUNG_UNRESOLVABLE
+        assert nowhere.anchor_status == ANCHOR_UNKNOWN_EVENT
+
+    def test_a_real_id_with_another_events_text_is_a_mislabelling(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        """Genuine evidence attached to the wrong event. Not a fabrication, and not resolved."""
+        loc = locate_quote(trajectory, 'you see a cd 3', anchor='evt_claim')
+        assert loc.rung == RUNG_EXACT
+        assert loc.event_id == 'evt_desk'
+        assert loc.anchor == 'evt_claim'
+        assert loc.anchor_status == ANCHOR_ELSEWHERE
+
+    def test_the_caller_anchor_wins_over_an_embedded_one(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        loc = locate_quote(trajectory, 'evt_plan: you see a cd 3', anchor='evt_desk')
+        assert loc.anchor == 'evt_desk'
+        assert loc.anchor_status == ANCHOR_RESOLVED
+
+    def test_the_anchor_event_is_searched_first(self) -> None:
+        """Text present in two events is credited to the one the finding names."""
+        traj = AgentTrajectory(trace_id='t2')
+        for i, eid in enumerate(('evt_a', 'evt_b')):
+            traj.add_event(AgentEvent(
+                event_id=eid, trace_id='t2', event_type=EventType.OBSERVATION,
+                step_index=i, output='carrier nimbus',
+            ))
+        assert locate_quote(traj, 'carrier nimbus').event_id == 'evt_a'
+        assert locate_quote(traj, 'carrier nimbus', anchor='evt_b').event_id == 'evt_b'
+
+
+class TestRegions:
+    def test_the_goal_is_typed_not_rejected_and_grounds_nothing(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        loc = locate_quote(trajectory, 'book under the desklamp')
+        assert loc.rung == RUNG_EXACT, 'it is a faithful quote'
+        assert loc.region == 'goal'
+        assert loc.event_id is None
+        assert loc.span is not None and GOAL[loc.span[0]:loc.span[1]] == loc.text
+        assert not loc.grounded, 'faithful, and not evidence about what the agent did'
+
+    def test_an_event_wins_a_tie_with_the_goal(self, trajectory: AgentTrajectory) -> None:
+        traj = AgentTrajectory(trace_id='t3', goal=DESK, events=list(trajectory.events))
+        assert locate_quote(traj, 'you see a cd 3').region == 'event'
+
+    def test_shown_is_a_permitted_weaker_region(self, trajectory: AgentTrajectory) -> None:
+        """A quote of the rendered summary resolves, and says so."""
+        shown = {'evt_desk': 'Summary: the desk holds a cd, a phone and a pen.'}
+        loc = locate_quote(trajectory, 'holds a cd, a phone', shown=shown)
+        assert loc.region == 'shown'
+        assert loc.event_id == 'evt_desk' and loc.field is None
+        assert loc.span is not None
+        assert shown['evt_desk'][loc.span[0]:loc.span[1]] == 'holds a cd, a phone'
+        assert loc.grounded
+
+    def test_input_and_error_fields_are_searched(self) -> None:
+        traj = AgentTrajectory(trace_id='t4')
+        traj.add_event(AgentEvent(
+            event_id='evt_call', trace_id='t4', event_type=EventType.TOOL_CALL,
+            step_index=0, input={'tool': 'open', 'target': 'fridge 1'},
+            error='PermissionError: fridge 1 is locked',
+        ))
+        by_input = locate_quote(traj, "'target': 'fridge 1'")
+        assert (by_input.rung, by_input.field) == (RUNG_EXACT, 'input')
+        by_error = locate_quote(traj, 'fridge 1 is locked')
+        assert (by_error.rung, by_error.field) == (RUNG_EXACT, 'error')
+
+
+class TestJsonEscapedSource:
+    """The case upstream commit 3438845 fixed for verification must locate too."""
+
+    ESCAPED = json.dumps({'content': "def f():\n    '''doc'''\n    return 1"})
+
+    def _traj(self) -> AgentTrajectory:
+        traj = AgentTrajectory(trace_id='t5')
+        traj.add_event(AgentEvent(
+            event_id='evt_src', trace_id='t5', event_type=EventType.TOOL_RESULT,
+            step_index=0, output=self.ESCAPED,
+        ))
+        return traj
+
+    def test_a_quote_with_real_newlines_locates_in_the_escaped_field(self) -> None:
+        traj = self._traj()
+        assert '\\n' in self.ESCAPED and '\n' not in self.ESCAPED
+        loc = locate_quote(traj, "def f():\n    '''doc'''")
+        assert loc.rung == RUNG_NORMALIZED
+        assert loc.field == 'output'
+        assert loc.span is not None
+        # The span is into the RAW escaped field, and covers the escape sequences.
+        assert self.ESCAPED[loc.span[0]:loc.span[1]] == loc.text
+        assert loc.text is not None and loc.text.startswith('def f():\\n')
+        assert _norm(loc.text) == _norm("def f():\n    '''doc'''")
+
+    def test_location_and_verification_agree(self) -> None:
+        traj = self._traj()
+        finding = FailureFinding(
+            failure_mode=MODE, event_id='evt_src', step_index=0,
+            wrong_content_quote="def f():\n    '''doc'''",
+            reference_quote='return 1', conflict_with=ConflictAxis.SELF,
+        )
+        assert verify_finding_quotes(finding, traj) is True
+        [grounding] = grounds_trajectory([finding], traj)
+        assert grounding.grounded is True
+
+
+class TestNormalizationMap:
+    @pytest.mark.parametrize('text', [
+        'plain',
+        '  padded\t\ttext \n',
+        'a\\nb\\tc\\"d\\\'e',
+        'double\\\\n escape',
+        'nbsp here and em',
+        '',
+        '   ',
+        'trailing escape\\',
+    ])
+    def test_the_map_reproduces_norm_exactly(self, text: str) -> None:
+        """Location and verification must agree, so the mapped text IS ``_norm``."""
+        mapped, spans = _norm_with_map(text)
+        assert mapped == _norm(text)
+        assert len(spans) == len(mapped)
+        for (start, end), char in zip(spans, mapped):
+            assert 0 <= start < end <= len(text)
+            if char != ' ':
+                assert _norm(text[start:end]) == char
+
+
+class TestGroundsTrajectory:
+    def test_evidence_after_the_blamed_step_is_hindsight(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        """Verbatim, and still not evidence: the verdict came after the act."""
+        finding = _finding(
+            wrong_content_quote='The desk has a desklamp',
+            reference_quote='the book was never taken',
+            conflict_with=ConflictAxis.CONTEXT,
+        )
+        assert verify_finding_quotes(finding, trajectory) is True, 'the boolean cannot see this'
+        [g] = grounds_trajectory([finding], trajectory)
+        wrong, reference = g.quotes
+        assert (wrong.role, wrong.position, wrong.at_or_before_blame) == ('wrong_content', 'at', True)
+        assert wrong.location.anchor_status == ANCHOR_RESOLVED
+        assert (reference.role, reference.position) == ('reference', 'after')
+        assert reference.at_or_before_blame is False
+        assert reference.location.grounded, 'the quote itself is real'
+        assert g.grounded is False
+
+    def test_evidence_before_the_blamed_step_grounds(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        finding = _finding(
+            wrong_content_quote='The desk has a desklamp',
+            reference_quote='you see a cd 3',
+            conflict_with=ConflictAxis.CONTEXT,
+        )
+        [g] = grounds_trajectory([finding], trajectory)
+        assert (g.blamed_event_id, g.blamed_event_index, g.blamed_step_index) == ('evt_claim', 2, 2)
+        assert [q.position for q in g.quotes] == ['at', 'before']
+        assert g.grounded is True
+
+    def test_a_wrong_content_quote_from_another_step_does_not_ground(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        finding = _finding(
+            wrong_content_quote='you see a cd 3',
+            reference_quote='survey the room',
+            conflict_with=ConflictAxis.SELF,
+        )
+        [g] = grounds_trajectory([finding], trajectory)
+        wrong = g.quotes[0]
+        assert wrong.location.rung == RUNG_EXACT
+        assert wrong.location.anchor_status == ANCHOR_ELSEWHERE
+        assert wrong.position == 'before'
+        assert g.grounded is False
+
+    def test_no_quotes_is_none_like_quote_verified(self, trajectory: AgentTrajectory) -> None:
+        [g] = grounds_trajectory([_finding()], trajectory)
+        assert g.quotes == ()
+        assert g.grounded is None
+
+    def test_an_unresolvable_quote_has_no_position(self, trajectory: AgentTrajectory) -> None:
+        finding = _finding(wrong_content_quote='never happened', reference_quote='nor this')
+        [g] = grounds_trajectory([finding], trajectory)
+        assert [q.location.rung for q in g.quotes] == [RUNG_ANCHORED, RUNG_UNRESOLVABLE]
+        assert g.quotes[0].position == 'at', 'the pointer places it; the text does not ground it'
+        assert g.quotes[1].position is None
+        assert g.quotes[1].at_or_before_blame is None
+        assert g.grounded is False
+
+    def test_a_finding_blaming_a_step_the_trajectory_lacks(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        finding = _finding(step=9, wrong_content_quote='you see a cd 3')
+        [g] = grounds_trajectory([finding], trajectory)
+        assert g.blamed_event_id is None
+        assert g.quotes[0].location.rung == RUNG_EXACT
+        assert g.quotes[0].position is None
+        assert g.grounded is False
+
+    def test_annotation_lands_next_to_quote_verified_and_is_json(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        finding = _finding(
+            wrong_content_quote='The desk has a desklamp',
+            reference_quote='you see a cd 3',
+            conflict_with=ConflictAxis.CONTEXT,
+        )
+        annotate_evidence_regions([finding], trajectory)
+        payload = finding.metadata['evidence_regions']
+        json.dumps(payload)
+        assert payload['grounded'] is True
+        assert payload['quotes'][1]['location']['event_id'] == 'evt_desk'
+        assert payload['quotes'][1]['location']['span'] == [15, 29]
+        assert payload['quotes'][1]['position'] == 'before'
+
+    def test_shown_is_threaded_through(self, trajectory: AgentTrajectory) -> None:
+        shown = {'evt_desk': 'Summary: the desk holds a cd, a phone and a pen.'}
+        finding = _finding(
+            wrong_content_quote='The desk has a desklamp',
+            reference_quote='holds a cd, a phone',
+            conflict_with=ConflictAxis.CONTEXT,
+        )
+        [g] = grounds_trajectory([finding], trajectory, shown)
+        assert g.quotes[1].location.region == 'shown'
+        assert g.grounded is True


### PR DESCRIPTION
## Motivation
`verify_finding_quotes` answers whether a quote resolves. Consumers that build training data from findings also need to know *where* it resolves and whether the agent could have seen it when it acted: evidence taken from an event after the blamed step is hindsight, and a diagnosis resting on it reasons from the outcome rather than from what was visible. AgentErrorData carries this logic privately today (`agent_error_data/evidence_region.py`, used by its record schema and its SFT exporter); this PR moves it upstream so the detector and its consumers share one definition.

## Design (`agentdebug/diagnose/detect/evidence.py`)
- `locate_quote(trajectory, quote, *, anchor=None, shown=None) -> QuoteLocation`: rungs tried strictest first (`exact` verbatim, `normalized` with the same normalisation `verify_finding_quotes` applies, `anchored` when only the declared event id resolves, `unresolvable`), region (`event` / `shown` / `goal` / `none`), event id, index, step, field and character span, and `anchor_status` (`resolved`, `elsewhere`, `unknown_event`, `not_declared`) kept separate from the rung because "the text is real but the id is wrong" differs from "the text is invented".
- Framed quotes (`[step N] event_id=evt_x ...`, `evt_x: ...`, `(evt_x)`, a bare `evt_x`) are split into the declared anchor and the content; the unframed content is tried verbatim before normalisation.
- `resolve_anchor(trajectory, event_id)`: exact match only.
- `grounds_trajectory(findings, trajectory, shown=None) -> list[FindingGrounding]`: every quote located and placed `before` / `at` / `after` the blamed event; `annotate_evidence_regions` writes the JSON payload into `finding.metadata['evidence_regions']` next to `quote_verified`.
- No provider calls, no behaviour change for existing callers; `verify_finding_quotes` is untouched.

## Tests
`tests/test_detect_evidence_regions.py`: every rung, anchors (resolved / elsewhere / invented), framing variants, JSON-escaped source, goal region, `shown` threading, blamed-step ordering, annotation payload. 34 new tests; the existing detect suite (165) passes.

## CI note
`ruff` clean on the changed files. `mypy` reports the same single pre-existing error on this file as on `main` (`dict` without type arguments, line 344, not touched here); main's CI has been red since 09-02 on the Ruff / Mypy contracts / Pydantic v1 jobs, which this PR does not address.

## Consumer
AgentErrorData will replace `evidence_region.py` with a thin import (schema_v2 evidence anchoring, export/sft_v2 citation gate, citation_grounding_census).