### PR TITLE
ingest: native tool-calling wire-protocol consistency checker

### DIFF
--- a/src/agentdebug/ingest/README.md
+++ b/src/agentdebug/ingest/README.md
@@ -41,3 +41,26 @@ their matching optional extras.
 - Keep normalized outputs aligned with `agentdebug.schema`.
 - Avoid leaking framework-specific objects into Diagnose.
 - Make adapter failures explicit and actionable.
+
+
+## Native tool-calling consistency (`agentdebug.ingest.native_protocol`)
+
+A transcript recorded from a provider's native tool-calling API carries two descriptions of
+every tool turn: the wire envelope (`messages` with `tool_calls` / `tool_call_id`) and the
+executed events (`agent.step` or `error` for the turn, `tool.call` / `tool.result` for what
+ran). They are written by different code paths and drift silently while every field stays
+schema-valid. `native_tool_protocol_violations(trajectory, trace_uid=...)` returns one record
+per disagreement (reason, message index, event ids) so a corpus audit can count by reason;
+`native_tool_message_violations(messages)` is the subset a strict provider would itself reject
+and needs no events, so an importer can run it on the raw export:
+
+```python
+from agentdebug.ingest import convert_payload
+traj = convert_payload(payload, format="messages", strict_native=True)  # raises ConversionError
+```
+
+Conventions the checker reads from a trajectory (all optional; without them it reports
+`NO_MESSAGES`): `trajectory.metadata["messages"]`, `event.metadata["prompt_n_messages"]` on the
+turn event, `event.metadata["tool_call_id"]` on `tool.call`, `event.input == {"tool", "args"}`,
+an `error` starting with `multiple_tool_calls:` for a refused multi-call turn, and
+`metadata["text_protocol_fallback"]` on a step that fell back to the text protocol.

--- a/src/agentdebug/ingest/__init__.py
+++ b/src/agentdebug/ingest/__init__.py
@@ -8,9 +8,15 @@ from agentdebug.ingest.importers import (
     detect_payload_format,
     write_converted_trajectory,
 )
+from agentdebug.ingest.native_protocol import (
+    native_tool_message_violations,
+    native_tool_protocol_violations,
+)
 from agentdebug.ingest.recorder import AgentDebug, TraceSession
 
 __all__ = [
+    'native_tool_message_violations',
+    'native_tool_protocol_violations',
     'AgentDebug',
     'AdapterStatus',
     'ConversionError',

--- a/src/agentdebug/ingest/adapters/importers.py
+++ b/src/agentdebug/ingest/adapters/importers.py
@@ -121,8 +121,15 @@ def convert_payload(
     task_id: Optional[str] = None,
     goal: Optional[str] = None,
     framework: Optional[str] = None,
+    strict_native: bool = False,
 ) -> AgentTrajectory:
     """Convert an offline trace payload into ``AgentTrajectory``.
+
+    ``strict_native=True`` refuses a ``messages`` export whose native tool-calling
+    envelope is inconsistent (an assistant ``tool_calls`` id not answered exactly
+    once, an orphan ``tool`` message, a missing or duplicate call id); see
+    :mod:`agentdebug.ingest.native_protocol`. The default stays lenient because
+    text-protocol transcripts carry no envelope at all.
 
     ``format='auto'`` is intended for CLI use and common exported logs. Pass an
     explicit format when a payload is ambiguous, for example a list of objects
@@ -148,6 +155,15 @@ def convert_payload(
         return traj
     if fmt in {'messages', 'message_list'}:
         messages = payload.get('messages') if isinstance(payload, dict) else payload
+        if strict_native:
+            from agentdebug.ingest.native_protocol import native_tool_message_violations
+
+            violations = native_tool_message_violations(
+                cast(Sequence[Any], messages), trace_uid=trace_id)
+            if violations:
+                reasons = sorted({str(v['reason']) for v in violations})
+                raise ConversionError(
+                    'native tool-calling envelope is inconsistent: ' + '; '.join(reasons))
         return _convert_messages_payload(
             payload if isinstance(payload, dict) else {'messages': messages},
             cast(Sequence[Dict[str, Any]], messages),

--- a/src/agentdebug/ingest/native_protocol.py
+++ b/src/agentdebug/ingest/native_protocol.py
@@ -1,0 +1,588 @@
+"""Consistency checks for stored native tool-calling transcripts.
+
+A trajectory recorded from a provider's native tool-calling API carries two
+descriptions of every tool turn: the wire envelope (the OpenAI-shaped
+``messages`` list, with ``tool_calls`` on assistant messages and
+``tool_call_id`` on tool messages) and the executed events (``agent.step`` /
+``error`` for the turn, ``tool.call`` / ``tool.result`` for what actually
+ran). The two are written by different code paths and drift silently: a
+multi-call assistant turn executed as one call, a tool message whose id no
+assistant message ever issued, a ``tool.call`` whose name or arguments are not
+what the envelope said. None of that is caught by schema validation, because
+every field is individually well-formed.
+
+This module answers "do the two descriptions agree?" for one trajectory, as
+a list of violation records rather than a boolean, so a corpus audit can
+count by reason and a strict ingest can refuse with a specific message.
+
+Conventions read from the trajectory (all optional; a trajectory that carries
+none of them is simply "not a native transcript" and yields
+:data:`NO_MESSAGES`):
+
+* ``trajectory.metadata['messages']`` -- the verbatim wire transcript.
+* ``event.metadata['prompt_n_messages']`` on ``agent.step`` / ``error``
+  events -- the index in ``messages`` of the assistant message that turn
+  produced (equivalently, how many messages were in the prompt).
+* ``event.metadata['tool_call_id']`` on ``tool.call`` events -- the provider
+  id of the call that ran.
+* ``event.input == {'tool': name, 'args': {...}}`` on ``tool.call`` and
+  ``event.input == {'tool': name}`` on ``tool.result``.
+* ``error`` starting with ``multiple_tool_calls:`` on an ``error`` event --
+  the harness rejected a multi-call turn without executing any of it.
+* ``leaked_tool_name`` on the step (in ``metadata`` or a dict ``output``) --
+  the provider corrupted the tool name in transit (for example by welding a
+  channel token onto it) and the harness executed the repaired name.
+* ``envelope == 'text_protocol_fallback'`` on the step -- the model answered
+  in a text action protocol instead of a native call, so the executed
+  ``tool.call`` legitimately has no provider id.
+
+:func:`native_tool_message_violations` checks the wire transcript alone,
+for importers that have the messages but no executed events yet.
+:func:`native_tool_protocol_violations` checks the full trajectory.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set
+
+from agentdebug.schema import AgentEvent, AgentTrajectory, EventType
+
+Violation = Dict[str, Any]
+"""One finding: always ``trace_uid`` and ``reason``; usually ``message_index``."""
+
+ArgumentParser = Callable[[str], Any]
+"""Parses the ``function.arguments`` string of a tool call into a value."""
+
+# --------------------------------------------------------------------------- #
+# Reason vocabulary. Stable strings: corpus audits count by them.
+# --------------------------------------------------------------------------- #
+
+NO_MESSAGES = 'native trace has no messages list'
+TOOL_CALLS_NOT_LIST = 'assistant tool_calls must be a non-empty list'
+CALL_ID_MISSING = 'assistant tool call has no non-empty id'
+CALL_IDS_NOT_UNIQUE = 'assistant tool call ids are not unique'
+CALLS_NOT_ANSWERED_ONCE = (
+    'assistant tool calls are not answered exactly once before next turn'
+)
+NO_UNIQUE_TURN_POINTER = 'native assistant turn has no unique step/error event pointer'
+MULTI_CALL_NOT_REJECTED = (
+    'multiple native calls were not rejected as one non-executed error turn'
+)
+REJECTED_CALL_EXECUTED = 'rejected native call has execution events'
+NO_UNIQUE_EXECUTION_PAIR = 'accepted native call has no unique call/result event pair'
+CALL_ID_DISAGREES = 'tool.call event id disagrees with assistant envelope'
+FUNCTION_NAME_MISSING = 'assistant tool call has no non-empty function name'
+CALL_NAME_DISAGREES = 'tool.call event name disagrees with assistant envelope'
+ARGS_NOT_OBJECT = 'accepted assistant tool arguments are not a JSON object'
+CALL_ARGS_DISAGREE = 'tool.call event args disagree with assistant envelope'
+RESULT_NAME_DISAGREES = 'tool.result event name disagrees with tool.call event'
+ORPHAN_TOOL_MESSAGE = (
+    'tool message has no immediately preceding assistant tool-call batch'
+)
+CALL_ID_WITHOUT_ENVELOPE = 'tool.call event id has no assistant envelope'
+CALL_WITHOUT_ID_OR_FALLBACK = (
+    'tool.call event has no provider id or declared text fallback'
+)
+
+#: Every reason this module can emit, in the order the checks run.
+REASONS = (
+    NO_MESSAGES,
+    TOOL_CALLS_NOT_LIST,
+    CALL_ID_MISSING,
+    CALL_IDS_NOT_UNIQUE,
+    CALLS_NOT_ANSWERED_ONCE,
+    NO_UNIQUE_TURN_POINTER,
+    MULTI_CALL_NOT_REJECTED,
+    REJECTED_CALL_EXECUTED,
+    NO_UNIQUE_EXECUTION_PAIR,
+    CALL_ID_DISAGREES,
+    FUNCTION_NAME_MISSING,
+    CALL_NAME_DISAGREES,
+    ARGS_NOT_OBJECT,
+    CALL_ARGS_DISAGREE,
+    RESULT_NAME_DISAGREES,
+    ORPHAN_TOOL_MESSAGE,
+    CALL_ID_WITHOUT_ENVELOPE,
+    CALL_WITHOUT_ID_OR_FALLBACK,
+)
+
+#: Reasons decidable from the wire transcript alone (no executed events needed).
+MESSAGE_REASONS = (
+    TOOL_CALLS_NOT_LIST,
+    CALL_ID_MISSING,
+    CALL_IDS_NOT_UNIQUE,
+    CALLS_NOT_ANSWERED_ONCE,
+    ORPHAN_TOOL_MESSAGE,
+)
+
+#: The ``error`` prefix a harness writes when it refuses a multi-call turn.
+MULTIPLE_TOOL_CALLS_PREFIX = 'multiple_tool_calls:'
+#: The step annotation that declares a text-protocol action without a provider id.
+TEXT_PROTOCOL_FALLBACK = 'text_protocol_fallback'
+
+_TURN_EVENT_TYPES = frozenset({EventType.AGENT_STEP.value, EventType.ERROR.value})
+_EXECUTION_EVENT_TYPES = frozenset(
+    {EventType.TOOL_CALL.value, EventType.TOOL_RESULT.value}
+)
+
+
+def parse_json_arguments(raw: str) -> Any:
+    """Default ``function.arguments`` parser: strict JSON, ``None`` when invalid.
+
+    Harnesses that repair provider output before executing it (raw newlines
+    inside a JSON string, a stray closing bracket) should pass the same
+    repair as ``parse_arguments`` so the check compares what the harness
+    actually saw; otherwise a repaired turn reads as :data:`ARGS_NOT_OBJECT`.
+    """
+    try:
+        return json.loads(raw)
+    except ValueError:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Wire transcript
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class _AssistantTurn:
+    """One assistant message carrying ``tool_calls``, after the wire checks."""
+
+    index: int
+    calls: List[Any]
+    call_ids: List[str]
+    violations: List[Violation] = field(default_factory=list)
+    #: False when a wire check already rejected the turn outright; the
+    #: event-level checks do not run on it.
+    checkable: bool = True
+
+
+@dataclass
+class _WireScan:
+    turns: List[_AssistantTurn]
+    claimed_tool_indexes: Set[int]
+    envelope_call_ids: Set[str]
+    orphans: List[Violation]
+
+
+def _scan_wire(messages: Sequence[Any], trace_uid: str) -> _WireScan:
+    turns: List[_AssistantTurn] = []
+    claimed: Set[int] = set()
+    envelope_call_ids: Set[str] = set()
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict) or message.get('role') != 'assistant':
+            continue
+        calls = message.get('tool_calls')
+        if calls is None:
+            continue
+        turn = _AssistantTurn(index=index, calls=[], call_ids=[])
+        turns.append(turn)
+        if not isinstance(calls, list) or not calls:
+            turn.violations.append(
+                _violation(trace_uid, TOOL_CALLS_NOT_LIST, message_index=index)
+            )
+            turn.checkable = False
+            continue
+        turn.calls = calls
+
+        tool_ids: List[Any] = []
+        for following_index in range(index + 1, len(messages)):
+            following = messages[following_index]
+            if not isinstance(following, dict) or following.get('role') != 'tool':
+                break
+            claimed.add(following_index)
+            tool_ids.append(following.get('tool_call_id'))
+
+        raw_ids = [call.get('id') if isinstance(call, dict) else None for call in calls]
+        if any(not isinstance(call_id, str) or not call_id for call_id in raw_ids):
+            turn.violations.append(
+                _violation(trace_uid, CALL_ID_MISSING, message_index=index)
+            )
+            turn.checkable = False
+            continue
+        call_ids: List[str] = [str(call_id) for call_id in raw_ids]
+        turn.call_ids = call_ids
+        envelope_call_ids.update(call_ids)
+        if len(set(call_ids)) != len(call_ids):
+            turn.violations.append(
+                _violation(
+                    trace_uid, CALL_IDS_NOT_UNIQUE, message_index=index, call_ids=call_ids
+                )
+            )
+        if Counter(tool_ids) != Counter(call_ids):
+            turn.violations.append(
+                _violation(
+                    trace_uid,
+                    CALLS_NOT_ANSWERED_ONCE,
+                    message_index=index,
+                    call_ids=call_ids,
+                    tool_result_ids=tool_ids,
+                )
+            )
+
+    orphans: List[Violation] = []
+    for index, message in enumerate(messages):
+        if (
+            isinstance(message, dict)
+            and message.get('role') == 'tool'
+            and index not in claimed
+        ):
+            orphans.append(
+                _violation(
+                    trace_uid,
+                    ORPHAN_TOOL_MESSAGE,
+                    message_index=index,
+                    tool_call_id=message.get('tool_call_id'),
+                )
+            )
+    return _WireScan(
+        turns=turns,
+        claimed_tool_indexes=claimed,
+        envelope_call_ids=envelope_call_ids,
+        orphans=orphans,
+    )
+
+
+def native_tool_message_violations(
+    messages: Sequence[Any], *, trace_uid: Optional[str] = None
+) -> List[Violation]:
+    """Check an OpenAI-shaped ``messages`` list on its own.
+
+    Every assistant ``tool_calls`` id must be non-empty and unique within its
+    turn, and must be answered by exactly one ``tool`` message before the
+    next non-tool message; every ``tool`` message must sit in such a batch.
+    This is the subset of :func:`native_tool_protocol_violations` a strict
+    provider would itself reject, and it needs no executed events, so an
+    importer can run it on the raw export. Reasons: :data:`MESSAGE_REASONS`.
+    """
+    scan = _scan_wire(messages, trace_uid or '')
+    violations: List[Violation] = []
+    for turn in scan.turns:
+        violations.extend(turn.violations)
+    violations.extend(scan.orphans)
+    return violations
+
+
+# --------------------------------------------------------------------------- #
+# Full trajectory
+# --------------------------------------------------------------------------- #
+
+
+def native_tool_protocol_violations(
+    trajectory: AgentTrajectory,
+    *,
+    trace_uid: Optional[str] = None,
+    parse_arguments: Optional[ArgumentParser] = None,
+) -> List[Violation]:
+    """Find native turns whose stored wire envelope disagrees with the executed turn.
+
+    Runs the wire checks of :func:`native_tool_message_violations`, then for
+    each assistant tool-call turn requires exactly one ``agent.step`` or
+    ``error`` event pointing at it (``prompt_n_messages``); a multi-call turn
+    must be that ``error`` event with a ``multiple_tool_calls:`` error and no
+    execution; a single accepted call must have exactly one ``tool.call`` and
+    one ``tool.result`` at the same ``step_index`` agreeing with the envelope
+    on id, name and arguments; and every ``tool.call`` event must carry an id
+    the envelope issued or belong to a step that declared a text fallback.
+
+    ``trace_uid`` labels every record (defaults to ``trajectory.trace_id``).
+    ``parse_arguments`` replaces :func:`parse_json_arguments` when the harness
+    repaired the provider's argument string before executing it.
+    """
+    uid = trace_uid if trace_uid is not None else trajectory.trace_id
+    parse = parse_arguments or parse_json_arguments
+    messages = trajectory.metadata.get('messages')
+    if not isinstance(messages, list):
+        return [_violation(uid, NO_MESSAGES)]
+
+    turn_events: Dict[int, List[AgentEvent]] = defaultdict(list)
+    execution_events: Dict[int, List[AgentEvent]] = defaultdict(list)
+    for event in trajectory.events:
+        kind = _event_type(event)
+        if kind in _TURN_EVENT_TYPES:
+            pointer = event.metadata.get('prompt_n_messages')
+            if _is_int(pointer):
+                turn_events[pointer].append(event)
+        elif kind in _EXECUTION_EVENT_TYPES and _is_int(event.step_index):
+            execution_events[event.step_index].append(event)
+
+    scan = _scan_wire(messages, uid)
+    violations: List[Violation] = []
+    for turn in scan.turns:
+        violations.extend(turn.violations)
+        if not turn.checkable:
+            continue
+        events = turn_events.get(turn.index, [])
+        if len(events) != 1:
+            violations.append(
+                _violation(
+                    uid,
+                    NO_UNIQUE_TURN_POINTER,
+                    message_index=turn.index,
+                    matching_events=len(events),
+                )
+            )
+            continue
+        event = events[0]
+        if len(turn.calls) > 1:
+            if not _is_rejected_multi_call(event):
+                violations.append(
+                    _violation(
+                        uid,
+                        MULTI_CALL_NOT_REJECTED,
+                        message_index=turn.index,
+                        call_ids=turn.call_ids,
+                        event_type=_event_type(event),
+                        event_error=event.error,
+                    )
+                )
+                continue
+            # A rejected multi-call turn must not have run anything: a call or
+            # result event at its step means the harness executed a partial turn
+            # after telling the model it had refused it.
+            step_index = event.step_index
+            ran = execution_events.get(step_index, []) if _is_int(step_index) else []
+            if ran:
+                violations.append(
+                    _violation(
+                        uid,
+                        REJECTED_CALL_EXECUTED,
+                        message_index=turn.index,
+                        tool_call_events=sum(
+                            1 for item in ran
+                            if _event_type(item) == EventType.TOOL_CALL.value
+                        ),
+                        tool_result_events=sum(
+                            1 for item in ran
+                            if _event_type(item) == EventType.TOOL_RESULT.value
+                        ),
+                    )
+                )
+            continue
+        violations.extend(
+            _check_single_call(uid, turn, event, execution_events, parse)
+        )
+
+    violations.extend(scan.orphans)
+    violations.extend(
+        _check_tool_call_events(uid, trajectory, scan.envelope_call_ids)
+    )
+    return violations
+
+
+def _check_single_call(
+    trace_uid: str,
+    turn: _AssistantTurn,
+    event: AgentEvent,
+    execution_events: Dict[int, List[AgentEvent]],
+    parse: ArgumentParser,
+) -> List[Violation]:
+    index = turn.index
+    step_index = event.step_index
+    step_execution = execution_events.get(step_index, []) if _is_int(step_index) else []
+    call_events = [
+        item for item in step_execution if _event_type(item) == EventType.TOOL_CALL.value
+    ]
+    result_events = [
+        item
+        for item in step_execution
+        if _event_type(item) == EventType.TOOL_RESULT.value
+    ]
+    if _event_type(event) == EventType.ERROR.value:
+        if call_events or result_events:
+            return [
+                _violation(
+                    trace_uid,
+                    REJECTED_CALL_EXECUTED,
+                    message_index=index,
+                    tool_call_events=len(call_events),
+                    tool_result_events=len(result_events),
+                )
+            ]
+        return []
+    if len(call_events) != 1 or len(result_events) != 1:
+        return [
+            _violation(
+                trace_uid,
+                NO_UNIQUE_EXECUTION_PAIR,
+                message_index=index,
+                tool_call_events=len(call_events),
+                tool_result_events=len(result_events),
+            )
+        ]
+
+    violations: List[Violation] = []
+    call = turn.calls[0]
+    function = call.get('function') if isinstance(call, dict) else None
+    function = function if isinstance(function, dict) else {}
+    expected_name = function.get('name')
+    raw_args = function.get('arguments')
+    expected_args = parse(raw_args) if isinstance(raw_args, str) else raw_args
+    executed = call_events[0]
+    executed_input = executed.input if isinstance(executed.input, dict) else {}
+    executed_id = executed.metadata.get('tool_call_id')
+    executed_name = executed_input.get('tool')
+    executed_args = executed_input.get('args')
+    leaked_name = _step_annotation(event, 'leaked_tool_name')
+
+    if executed_id != turn.call_ids[0]:
+        violations.append(
+            _violation(
+                trace_uid,
+                CALL_ID_DISAGREES,
+                message_index=index,
+                assistant_tool_call_id=turn.call_ids[0],
+                event_tool_call_id=executed_id,
+            )
+        )
+    if not isinstance(expected_name, str) or not expected_name:
+        violations.append(
+            _violation(trace_uid, FUNCTION_NAME_MISSING, message_index=index)
+        )
+    elif executed_name != expected_name and leaked_name != expected_name:
+        violations.append(
+            _violation(
+                trace_uid,
+                CALL_NAME_DISAGREES,
+                message_index=index,
+                assistant_tool_name=expected_name,
+                event_tool_name=executed_name,
+            )
+        )
+    if not isinstance(expected_args, dict):
+        violations.append(_violation(trace_uid, ARGS_NOT_OBJECT, message_index=index))
+    elif executed_args != expected_args:
+        violations.append(
+            _violation(
+                trace_uid,
+                CALL_ARGS_DISAGREE,
+                message_index=index,
+                assistant_args=expected_args,
+                event_args=executed_args,
+            )
+        )
+
+    result_input = (
+        result_events[0].input if isinstance(result_events[0].input, dict) else {}
+    )
+    if result_input.get('tool') != executed_name:
+        violations.append(
+            _violation(
+                trace_uid,
+                RESULT_NAME_DISAGREES,
+                message_index=index,
+                tool_call_name=executed_name,
+                tool_result_name=result_input.get('tool'),
+            )
+        )
+    return violations
+
+
+def _check_tool_call_events(
+    trace_uid: str, trajectory: AgentTrajectory, envelope_call_ids: set
+) -> List[Violation]:
+    violations: List[Violation] = []
+    for event in trajectory.events:
+        if _event_type(event) != EventType.TOOL_CALL.value:
+            continue
+        call_id = event.metadata.get('tool_call_id')
+        if isinstance(call_id, str) and call_id:
+            if call_id not in envelope_call_ids:
+                violations.append(
+                    _violation(
+                        trace_uid,
+                        CALL_ID_WITHOUT_ENVELOPE,
+                        event_tool_call_id=call_id,
+                        step_index=event.step_index,
+                    )
+                )
+            continue
+        declared_fallback = any(
+            _step_annotation(item, 'envelope') == TEXT_PROTOCOL_FALLBACK
+            for item in trajectory.events
+            if _event_type(item) == EventType.AGENT_STEP.value
+            and item.step_index == event.step_index
+        )
+        if not declared_fallback:
+            violations.append(
+                _violation(
+                    trace_uid,
+                    CALL_WITHOUT_ID_OR_FALLBACK,
+                    step_index=event.step_index,
+                )
+            )
+    return violations
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _violation(trace_uid: str, reason: str, **detail: Any) -> Violation:
+    record: Violation = {'trace_uid': trace_uid}
+    message_index = detail.pop('message_index', None)
+    if message_index is not None:
+        record['message_index'] = message_index
+    record['reason'] = reason
+    record.update(detail)
+    return record
+
+
+def _event_type(event: AgentEvent) -> str:
+    """The event type as its string value, whether stored as enum or str."""
+    value = event.event_type
+    return value.value if isinstance(value, EventType) else str(value)
+
+
+def _is_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_rejected_multi_call(event: AgentEvent) -> bool:
+    return _event_type(event) == EventType.ERROR.value and str(
+        event.error or ''
+    ).startswith(MULTIPLE_TOOL_CALLS_PREFIX)
+
+
+def _step_annotation(event: AgentEvent, key: str) -> Any:
+    """Read a harness annotation from ``metadata`` or, failing that, a dict ``output``."""
+    if key in event.metadata:
+        return event.metadata.get(key)
+    if isinstance(event.output, dict):
+        return event.output.get(key)
+    return None
+
+
+__all__ = [
+    'ARGS_NOT_OBJECT',
+    'CALLS_NOT_ANSWERED_ONCE',
+    'CALL_ARGS_DISAGREE',
+    'CALL_IDS_NOT_UNIQUE',
+    'CALL_ID_DISAGREES',
+    'CALL_ID_MISSING',
+    'CALL_ID_WITHOUT_ENVELOPE',
+    'CALL_NAME_DISAGREES',
+    'CALL_WITHOUT_ID_OR_FALLBACK',
+    'FUNCTION_NAME_MISSING',
+    'MESSAGE_REASONS',
+    'MULTIPLE_TOOL_CALLS_PREFIX',
+    'MULTI_CALL_NOT_REJECTED',
+    'NO_MESSAGES',
+    'NO_UNIQUE_EXECUTION_PAIR',
+    'NO_UNIQUE_TURN_POINTER',
+    'ORPHAN_TOOL_MESSAGE',
+    'REASONS',
+    'REJECTED_CALL_EXECUTED',
+    'RESULT_NAME_DISAGREES',
+    'TEXT_PROTOCOL_FALLBACK',
+    'TOOL_CALLS_NOT_LIST',
+    'Violation',
+    'native_tool_message_violations',
+    'native_tool_protocol_violations',
+    'parse_json_arguments',
+]

--- a/tests/test_native_protocol.py
+++ b/tests/test_native_protocol.py
@@ -1,0 +1,172 @@
+"""The native tool-calling wire envelope must agree with the executed events.
+
+Each test builds the smallest trajectory that exhibits one reason from
+``agentdebug.ingest.native_protocol.REASONS`` and asserts that exactly that
+reason is reported; the first test is the consistent transcript every other
+test perturbs, so a regression that reports nothing for everything fails here.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentdebug.ingest import ConversionError, convert_payload
+from agentdebug.ingest import native_protocol as npm
+from agentdebug.schema import AgentEvent, AgentTrajectory, EventType
+
+TRACE = 'tr-native'
+
+
+def _messages(*, call_id: str = 'call_1', name: str = 'lookup', args: str = '{"q": "cd"}',
+              extra_calls: int = 0, answer_id: str | None = 'call_1') -> list[dict]:
+    calls = [{'id': call_id, 'type': 'function',
+              'function': {'name': name, 'arguments': args}}]
+    for k in range(extra_calls):
+        calls.append({'id': f'{call_id}_x{k}', 'type': 'function',
+                      'function': {'name': name, 'arguments': args}})
+    msgs: list[dict] = [
+        {'role': 'system', 'content': 'You are an agent.'},
+        {'role': 'user', 'content': 'Find the cd.'},
+        {'role': 'assistant', 'content': None, 'tool_calls': calls},
+    ]
+    if answer_id is not None:
+        msgs.append({'role': 'tool', 'tool_call_id': answer_id, 'content': 'cd 3 on desk 1'})
+    return msgs
+
+
+def _trajectory(messages: list[dict], events: list[AgentEvent] | None = None) -> AgentTrajectory:
+    return AgentTrajectory(trace_id=TRACE, metadata={'messages': messages},
+                           events=events if events is not None else _executed())
+
+
+def _executed(*, call_id: str = 'call_1', name: str = 'lookup', args: dict | None = None,
+              pointer: int = 2, step: int = 0, result_name: str | None = None) -> list[AgentEvent]:
+    args = {'q': 'cd'} if args is None else args
+    return [
+        AgentEvent(trace_id=TRACE, event_type=EventType.AGENT_STEP, step_index=step,
+                   output='calling lookup', metadata={'prompt_n_messages': pointer}),
+        AgentEvent(trace_id=TRACE, event_type=EventType.TOOL_CALL, step_index=step,
+                   input={'tool': name, 'args': args}, metadata={'tool_call_id': call_id}),
+        AgentEvent(trace_id=TRACE, event_type=EventType.TOOL_RESULT, step_index=step,
+                   input={'tool': result_name or name}, output='cd 3 on desk 1'),
+    ]
+
+
+def _reasons(trajectory: AgentTrajectory) -> list[str]:
+    return [v['reason'] for v in npm.native_tool_protocol_violations(trajectory, trace_uid=TRACE)]
+
+
+def test_consistent_single_call_turn_has_no_violations() -> None:
+    assert _reasons(_trajectory(_messages())) == []
+
+
+def test_every_reason_is_a_distinct_string() -> None:
+    assert len(set(npm.REASONS)) == len(npm.REASONS)
+    assert set(npm.MESSAGE_REASONS) <= set(npm.REASONS)
+
+
+def test_no_messages_is_reported_not_crashed() -> None:
+    traj = AgentTrajectory(trace_id=TRACE, events=_executed())
+    assert _reasons(traj) == [npm.NO_MESSAGES]
+
+
+def test_tool_calls_must_be_a_non_empty_list() -> None:
+    msgs = _messages()
+    msgs[2]['tool_calls'] = []
+    assert npm.TOOL_CALLS_NOT_LIST in _reasons(_trajectory(msgs))
+
+
+def test_call_id_missing_and_duplicate_ids() -> None:
+    msgs = _messages(call_id='')
+    assert npm.CALL_ID_MISSING in _reasons(_trajectory(msgs, _executed(call_id='')))
+    dup = _messages(extra_calls=1)
+    dup[2]['tool_calls'][1]['id'] = 'call_1'
+    assert npm.CALL_IDS_NOT_UNIQUE in _reasons(_trajectory(dup))
+
+
+def test_unanswered_call_and_orphan_tool_message() -> None:
+    unanswered = _messages(answer_id=None)
+    assert npm.CALLS_NOT_ANSWERED_ONCE in _reasons(_trajectory(unanswered))
+    orphan = _messages()
+    orphan.append({'role': 'user', 'content': 'and then?'})
+    orphan.append({'role': 'tool', 'tool_call_id': 'call_never_issued', 'content': 'x'})
+    assert npm.ORPHAN_TOOL_MESSAGE in _reasons(_trajectory(orphan))
+
+
+def test_stale_envelope_replayed_without_a_turn_pointer() -> None:
+    """The bug this module was written for: a second assistant envelope no event produced."""
+    msgs = _messages()
+    msgs.append({'role': 'assistant', 'content': None, 'tool_calls': [
+        {'id': 'call_2', 'type': 'function', 'function': {'name': 'lookup', 'arguments': '{}'}}]})
+    msgs.append({'role': 'tool', 'tool_call_id': 'call_2', 'content': 'again'})
+    assert npm.NO_UNIQUE_TURN_POINTER in _reasons(_trajectory(msgs))
+
+
+def test_multi_call_turn_must_be_rejected_not_executed() -> None:
+    msgs = _messages(extra_calls=1, answer_id=None)
+    msgs.append({'role': 'tool', 'tool_call_id': 'call_1', 'content': 'a'})
+    msgs.append({'role': 'tool', 'tool_call_id': 'call_1_x0', 'content': 'b'})
+    executed_anyway = _executed()
+    assert npm.MULTI_CALL_NOT_REJECTED in _reasons(_trajectory(msgs, executed_anyway))
+    rejected = [AgentEvent(trace_id=TRACE, event_type=EventType.ERROR, step_index=0,
+                           error='multiple_tool_calls: expected exactly one tool call, got 2',
+                           metadata={'prompt_n_messages': 2})]
+    assert _reasons(_trajectory(msgs, rejected)) == []
+    rejected_but_ran = rejected + _executed()[1:]
+    assert npm.REJECTED_CALL_EXECUTED in _reasons(_trajectory(msgs, rejected_but_ran))
+
+
+def test_accepted_call_needs_one_call_and_one_result_event() -> None:
+    only_step = _executed()[:1]
+    assert npm.NO_UNIQUE_EXECUTION_PAIR in _reasons(_trajectory(_messages(), only_step))
+
+
+def test_envelope_and_event_must_agree_on_id_name_and_args() -> None:
+    assert npm.CALL_ID_DISAGREES in _reasons(_trajectory(_messages(), _executed(call_id='call_9')))
+    assert npm.CALL_NAME_DISAGREES in _reasons(_trajectory(_messages(), _executed(name='other')))
+    assert npm.CALL_ARGS_DISAGREE in _reasons(_trajectory(_messages(), _executed(args={'q': 'dvd'})))
+    assert npm.RESULT_NAME_DISAGREES in _reasons(
+        _trajectory(_messages(), _executed(result_name='other')))
+
+
+def test_function_name_missing_and_arguments_not_an_object() -> None:
+    assert npm.FUNCTION_NAME_MISSING in _reasons(_trajectory(_messages(name=''), _executed(name='')))
+    assert npm.ARGS_NOT_OBJECT in _reasons(_trajectory(_messages(args='[1, 2]')))
+
+
+def test_tool_call_event_without_envelope_or_text_fallback() -> None:
+    events = _executed()
+    stray = AgentEvent(trace_id=TRACE, event_type=EventType.TOOL_CALL, step_index=1,
+                       input={'tool': 'lookup', 'args': {}}, metadata={'tool_call_id': 'call_ghost'})
+    assert npm.CALL_ID_WITHOUT_ENVELOPE in _reasons(_trajectory(_messages(), events + [stray]))
+    no_id = AgentEvent(trace_id=TRACE, event_type=EventType.TOOL_CALL, step_index=1,
+                       input={'tool': 'lookup', 'args': {}})
+    assert npm.CALL_WITHOUT_ID_OR_FALLBACK in _reasons(_trajectory(_messages(), events + [no_id]))
+
+
+def test_message_level_checks_run_on_the_raw_export() -> None:
+    reasons = [v['reason'] for v in npm.native_tool_message_violations(_messages(answer_id=None))]
+    assert reasons == [npm.CALLS_NOT_ANSWERED_ONCE]
+    assert npm.native_tool_message_violations(_messages()) == []
+
+
+def test_parse_json_arguments_is_strict() -> None:
+    assert npm.parse_json_arguments('{"a": 1}') == {'a': 1}
+    assert npm.parse_json_arguments('{a: 1}') is None
+    assert npm.parse_json_arguments('') is None
+
+
+def test_violation_records_are_json_and_carry_the_trace_uid() -> None:
+    [record] = npm.native_tool_protocol_violations(
+        AgentTrajectory(trace_id='other', events=[]), trace_uid=TRACE)
+    json.dumps(record)
+    assert record['trace_uid'] == TRACE and record['reason'] == npm.NO_MESSAGES
+
+
+def test_convert_payload_strict_native_refuses_an_invalid_export() -> None:
+    payload = {'messages': _messages(answer_id=None)}
+    convert_payload(payload, format='messages')  # lenient default still converts
+    with pytest.raises(ConversionError, match=npm.CALLS_NOT_ANSWERED_ONCE[:20]):
+        convert_payload(payload, format='messages', strict_native=True)
+    assert convert_payload({'messages': _messages()}, format='messages', strict_native=True)


### PR DESCRIPTION
## Motivation
A native tool-calling transcript stores two descriptions of each tool turn: the provider-shaped `messages` (assistant `tool_calls`, `tool` messages with `tool_call_id`) and the executed events (`agent.step` / `error`, `tool.call` / `tool.result`). They are produced by different code paths and can disagree while every field stays schema-valid. AgentErrorData found exactly this in production (a harness kept the previous response's envelope when the next response had no tool call, then replayed it and appended an unmatched FORMAT ERROR; 26–85% of native traces in several corpora were affected) and audits it with a private checker. This PR moves that checker upstream so ingest can refuse such transcripts and corpus audits can count them by reason.

## Design (`agentdebug/ingest/native_protocol.py`)
- `native_tool_protocol_violations(trajectory, *, trace_uid=None, parse_arguments=None) -> list[dict]`: wire checks, then for every assistant tool-call turn exactly one `agent.step`/`error` event pointing at it (`metadata['prompt_n_messages']`), a multi-call turn must be an `error` event with a `multiple_tool_calls:` error and no execution at its step, a single accepted call needs exactly one `tool.call` and one `tool.result` at the same step agreeing with the envelope on id, name and (JSON-parsed) arguments, and every `tool.call` event must carry an id the envelope issued or belong to a step that declared `text_protocol_fallback`. 17 distinct reason strings (`REASONS`), each record JSON-serialisable with the trace uid and message/event indexes.
- `native_tool_message_violations(messages)`: the subset a strict provider itself rejects; needs no events.
- `convert_payload(..., strict_native=True)` raises `ConversionError` listing the reasons; the default stays lenient because text-protocol transcripts carry no envelope.
- Conventions read from the trajectory are documented in the module docstring and `ingest/README.md`; a trajectory without `metadata['messages']` reports `NO_MESSAGES` rather than crashing.

## Tests
`tests/test_native_protocol.py`: a consistent transcript reports nothing; one test per reason (perturbing that transcript), the raw-export subset, strict JSON argument parsing, JSON-serialisable records, and `strict_native` on `convert_payload`. 16 new tests; `tests/test_ingest.py` (23) still passes.

## CI note
`ruff` and `mypy` clean on `native_protocol.py`; `importers.py` keeps its 27 pre-existing mypy errors (unchanged count). main's CI has been red since 09-02 (Ruff / Mypy contracts / Pydantic v1), not addressed here.

## Consumer
AgentErrorData: `audit_mint_corpus` (mint audit v3), `audit_training_package`, `campaign_task_chunks` markers and the labelling preflight will import this instead of `agent_error_data/native_protocol.py`.