### PR TITLE
provenance(): version, git sha and dirty flag for consumers that stamp rows

### DIFF
--- a/src/agentdebug/provenance.py
+++ b/src/agentdebug/provenance.py
@@ -1,0 +1,69 @@
+"""Where this copy of AgentDebugX came from, for consumers that stamp rows.
+
+A row produced by a diagnosis is only reproducible if it records which
+AgentDebugX produced it. The distribution version is not enough: an editable
+install tracks a git checkout whose content moves while the version string
+stays put. ``provenance()`` therefore reports the installed version and, when
+the package is imported from a git checkout, the commit it is at and whether
+that checkout has uncommitted changes. Everything is read locally and never
+raises: a consumer stamping a million rows must not fail because ``git`` is
+missing on the host.
+"""
+from __future__ import annotations
+
+import platform
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agentdebug import __version__
+
+PACKAGE = 'agentdebugx'
+
+
+def _git(args: List[str], cwd: Path) -> Optional[str]:
+    try:
+        out = subprocess.run(
+            ['git', *args], cwd=str(cwd), capture_output=True, text=True, timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip() or None
+
+
+def _checkout_root(start: Path) -> Optional[Path]:
+    for candidate in (start, *start.parents):
+        if (candidate / '.git').exists():
+            return candidate
+    return None
+
+
+def provenance(package_dir: Optional[Path] = None) -> Dict[str, Any]:
+    """Return ``{"package", "version", "git_sha", "git_dirty", "python", "platform"}``.
+
+    ``git_sha`` and ``git_dirty`` are ``None`` unless the package is imported
+    from inside a git checkout and ``git`` answers; ``git_dirty`` is ``True``
+    when that checkout has uncommitted changes under the package directory.
+    """
+    here = Path(package_dir) if package_dir is not None else Path(__file__).resolve().parent
+    root = _checkout_root(here)
+    sha = _git(['rev-parse', 'HEAD'], root) if root else None
+    dirty: Optional[bool] = None
+    if root and sha:
+        status = _git(['status', '--porcelain', '--untracked-files=no', '--', str(here)], root)
+        dirty = bool(status)
+    return {
+        'package': PACKAGE,
+        'version': __version__,
+        'git_sha': sha,
+        'git_dirty': dirty,
+        'python': sys.version.split()[0],
+        'platform': platform.platform(),
+    }
+
+
+__all__ = ['provenance', 'PACKAGE']

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import agentdebug.provenance as provenance_module
+from agentdebug import __version__
+from agentdebug.provenance import provenance
+
+
+def test_provenance_reports_version_and_is_json() -> None:
+    info = provenance()
+    json.dumps(info)
+    assert info['package'] == 'agentdebugx'
+    assert info['version'] == __version__
+    assert set(info) == {'package', 'version', 'git_sha', 'git_dirty', 'python', 'platform'}
+
+
+def test_git_fields_track_a_checkout(tmp_path: Path) -> None:
+    subprocess.run(['git', 'init', '-q', str(tmp_path)], check=True)
+    pkg = tmp_path / 'pkg'
+    pkg.mkdir()
+    (pkg / 'x.py').write_text('x = 1\n')
+    env = {'GIT_AUTHOR_NAME': 't', 'GIT_AUTHOR_EMAIL': 't@t', 'GIT_COMMITTER_NAME': 't',
+           'GIT_COMMITTER_EMAIL': 't@t'}
+    subprocess.run(['git', '-C', str(tmp_path), 'add', '-A'], check=True)
+    subprocess.run(['git', '-C', str(tmp_path), 'commit', '-q', '-m', 'init'], check=True, env=env)
+    clean = provenance(pkg)
+    assert clean['git_sha'] and len(clean['git_sha']) == 40
+    assert clean['git_dirty'] is False
+    (pkg / 'x.py').write_text('x = 2\n')
+    assert provenance(pkg)['git_dirty'] is True
+
+
+def test_outside_a_checkout_the_git_fields_are_none(tmp_path: Path) -> None:
+    info = provenance(tmp_path)
+    assert info['git_sha'] is None and info['git_dirty'] is None
+
+
+def test_module_is_exported() -> None:
+    assert provenance_module.provenance is provenance


### PR DESCRIPTION
## Motivation
Consumers that store diagnosis outputs (AgentErrorData stamps every debug attempt with provider and engine provenance) need to record which AgentDebugX produced a row. `__version__` alone is not enough: an editable install tracks a git checkout whose content moves while the version string stays put.

## Design
`agentdebug.provenance.provenance(package_dir=None) -> dict` with `package`, `version`, `git_sha`, `git_dirty`, `python`, `platform`. `git_sha` / `git_dirty` come from `git rev-parse` / `git status --porcelain -- <package dir>` when the package is imported from inside a checkout and `git` answers within 5 s; otherwise `None`. Never raises.

## Tests
`tests/test_provenance.py`: JSON-serialisable, version equals `__version__`, git fields track a temporary checkout (clean → dirty), `None` outside a checkout. ruff and mypy clean.

## Consumer
AgentErrorData `attribution_provenance.py` will stamp `agentdebugx` provenance on every attempt row and aggregate report (docs/AGENTDEBUGX_INTEGRATION.md PR-B).