### PR TITLE
taxonomy_manifest: fingerprinted taxonomy manifest and classification contract

### DIFF
--- a/docs/taxonomy_manifest.md
+++ b/docs/taxonomy_manifest.md
@@ -1,0 +1,36 @@
+# Taxonomy manifest and classification contract
+
+`agentdebug.taxonomy_manifest` freezes `SEED_FAILURE_MODES` into a JSON-serialisable
+document with a content fingerprint and the package revision it came from, and defines a
+side-effect-free classification contract on top of it. A label stored in a corpus is only
+interpretable if the reader can recover the exact definitions the labeller saw; the
+fingerprint is how a corpus notices that its labels and its taxonomy drifted apart.
+
+```python
+from agentdebug.taxonomy_manifest import (
+    ClassificationRequest, cohens_kappa, compile_classification_prompt,
+    parse_classification_response, taxonomy_manifest,
+)
+
+manifest = taxonomy_manifest()             # 23 modes in 9 families, fingerprint, source_revision
+system, user = compile_classification_prompt(manifest, ClassificationRequest(
+    trace_uid="tr-1", task_statement="...", outcome_text="failed", window=rendered_tail))
+reply = my_client.complete(system=system, user=user)   # the consumer owns the call and its budget
+result = parse_classification_response(reply.text, manifest)
+```
+
+`ClassificationResult` carries `mode_id`, `family`, optional `submode`, `decisive_step`,
+`evidence_quote`, `rationale`, `confidence` in [0, 1], and an explicit `abstain` with one of
+`ABSTAIN_REASONS` (`infrastructure_fault`, `decisive_step_not_in_window`, `ambiguous`,
+`unknown_mode`, `malformed_response`, `unparsed`). Infrastructure faults and ambiguous cases
+are never forced into an agent-error family. `parse_classification_response` never raises:
+fenced JSON, trailing prose, an unknown mode id, duplicate keys and malformed JSON all map to a
+result or an abstention with the raw object preserved.
+
+The grouping from leaf modes to families keeps every family, including `verification`,
+`multiagent`, `multimodal` and `observation`. `cohens_kappa(labels_a, labels_b)` measures
+two-judge agreement over the items both labelled and returns `None` where kappa is undefined.
+
+Consumers keep provider calls, budgets, metering, trace binding and append-only storage; a
+row should record the manifest `fingerprint`, `source_revision` and the SHA-256 of the
+compiled prompt so the classification is reproducible from the stored reply.

--- a/src/agentdebug/taxonomy_manifest.py
+++ b/src/agentdebug/taxonomy_manifest.py
@@ -1,0 +1,384 @@
+"""A deterministic, fingerprinted manifest of the failure-mode taxonomy, and a
+side-effect-free classification contract built on it.
+
+Why a manifest and not the dict. A label written into a corpus is only
+interpretable if the reader can recover the exact definitions the labeller
+saw. ``SEED_FAILURE_MODES`` is a Python object that changes with the package;
+:func:`taxonomy_manifest` freezes it into a JSON-serialisable document with a
+content fingerprint, the package revision it came from, and the grouping from
+leaf modes to reportable families. Two installs of the same package yield the
+same fingerprint; any edit to a mode's text changes it, which is how a corpus
+notices that its labels and its taxonomy drifted apart.
+
+Why the contract is side-effect free. The manifest, the prompt compiler and
+the parser know nothing about providers, budgets, retries or storage. A
+consumer supplies the trajectory window, calls its own model client with the
+compiled prompt, and hands the reply text back to :func:`parse_classification_response`.
+Everything that costs money or writes to disk stays with the consumer, so the
+same classification is reproducible from ``(fingerprint, prompt_sha256, reply)``.
+
+Abstention is a first-class outcome. An infrastructure fault, a window that
+does not contain the decisive step, or a reply that names an unknown mode are
+returned as ``abstain=True`` with a reason, never forced into an agent-error
+family.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+from pydantic import BaseModel, Field
+
+from agentdebug import __version__
+from agentdebug.schema.taxonomy import SEED_FAILURE_MODES
+
+MANIFEST_SCHEMA_VERSION = '1.0.0'
+
+#: Reasons a classification may abstain instead of naming a mode.
+ABSTAIN_REASONS = (
+    'infrastructure_fault',   # tool/env/provider fault: no agent decision to classify
+    'decisive_step_not_in_window',
+    'ambiguous',              # two modes fit equally and the rationale cannot separate them
+    'unknown_mode',           # the reply named a mode the manifest does not contain
+    'malformed_response',     # no JSON object could be recovered from the reply
+    'unparsed',               # a JSON object was found but its fields do not fit the contract
+)
+
+
+class ManifestMode(BaseModel):
+    """One leaf mode as the labeller sees it."""
+
+    mode_id: str
+    name: str
+    family: str
+    description: str
+    signals: List[str] = Field(default_factory=list)
+    source: Optional[str] = None
+
+
+class TaxonomyManifest(BaseModel):
+    """The frozen taxonomy: modes, families, provenance and fingerprint."""
+
+    schema_version: str
+    taxonomy_version: str
+    source_revision: Dict[str, Any]
+    fingerprint: str
+    families: List[str]
+    modes: List[ManifestMode]
+
+    def mode_ids(self) -> List[str]:
+        return [mode.mode_id for mode in self.modes]
+
+    def family_of(self, mode_id: str) -> Optional[str]:
+        for mode in self.modes:
+            if mode.mode_id == mode_id:
+                return mode.family
+        return None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dict(self.model_dump())
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(',', ':'))
+
+
+def _fingerprint(modes: Sequence[ManifestMode]) -> str:
+    payload = [mode.model_dump() for mode in sorted(modes, key=lambda m: m.mode_id)]
+    return hashlib.sha256(_canonical_json(payload).encode('utf-8')).hexdigest()
+
+
+def taxonomy_manifest(
+    modes: Optional[Dict[str, Any]] = None,
+    *,
+    taxonomy_version: Optional[str] = None,
+    source_revision: Optional[Dict[str, Any]] = None,
+) -> TaxonomyManifest:
+    """Freeze ``SEED_FAILURE_MODES`` (or ``modes``) into a fingerprinted manifest.
+
+    ``taxonomy_version`` defaults to the package version, ``source_revision``
+    to :func:`agentdebug.provenance.provenance` when importable. The
+    fingerprint covers only the modes (id, name, family, description, signals,
+    source), so it is stable across hosts and Python versions and changes
+    exactly when a definition does. Modes are validated: ids unique, families
+    non-empty, every family in ``families`` used by at least one mode.
+    """
+    raw = SEED_FAILURE_MODES if modes is None else modes
+    listed: List[ManifestMode] = []
+    seen: Set[str] = set()
+    for key, mode in raw.items():
+        data = mode.model_dump() if hasattr(mode, 'model_dump') else dict(mode)
+        mode_id = data.get('mode_id') or key
+        if mode_id in seen:
+            raise ValueError(f'duplicate mode id in taxonomy: {mode_id!r}')
+        if mode_id != key:
+            raise ValueError(f'taxonomy key {key!r} disagrees with mode_id {mode_id!r}')
+        seen.add(mode_id)
+        listed.append(ManifestMode(
+            mode_id=mode_id, name=str(data.get('name') or mode_id),
+            family=str(data.get('family') or ''), description=str(data.get('description') or ''),
+            signals=[str(s) for s in (data.get('signals') or [])], source=data.get('source'),
+        ))
+    if any(not mode.family for mode in listed):
+        raise ValueError('every taxonomy mode needs a family')
+    families = sorted({mode.family for mode in listed})
+    if source_revision is None:
+        try:
+            from agentdebug.provenance import provenance
+
+            source_revision = provenance()
+        except Exception:  # pragma: no cover - provenance never raises, belt and braces
+            source_revision = {'package': 'agentdebugx', 'version': __version__}
+    listed.sort(key=lambda m: (m.family, m.mode_id))
+    return TaxonomyManifest(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        taxonomy_version=taxonomy_version or __version__,
+        source_revision=dict(source_revision),
+        fingerprint=_fingerprint(listed),
+        families=families,
+        modes=listed,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Classification contract
+# --------------------------------------------------------------------------- #
+
+
+class ClassificationRequest(BaseModel):
+    """What the judge is shown. The consumer renders the window; this only carries it."""
+
+    trace_uid: str
+    task_statement: str = ''
+    outcome_text: str = ''
+    window: str
+    window_complete: bool = True
+    candidate_steps: List[int] = Field(default_factory=list)
+
+
+class ClassificationResult(BaseModel):
+    """One judge verdict, or an explicit abstention.
+
+    ``mode_id`` and ``family`` are ``None`` exactly when ``abstain`` is true;
+    ``abstain_reason`` is then one of :data:`ABSTAIN_REASONS`. ``raw`` keeps
+    the JSON object as parsed so a consumer can store the verdict verbatim.
+    """
+
+    mode_id: Optional[str] = None
+    family: Optional[str] = None
+    submode: Optional[str] = None
+    decisive_step: Optional[int] = None
+    evidence_quote: str = ''
+    rationale: str = ''
+    confidence: float = 0.0
+    abstain: bool = False
+    abstain_reason: Optional[str] = None
+    raw: Dict[str, Any] = Field(default_factory=dict)
+
+
+
+def _render_taxonomy(manifest: TaxonomyManifest) -> str:
+    lines: List[str] = []
+    for family in manifest.families:
+        lines.append(f'## family: {family}')
+        for mode in manifest.modes:
+            if mode.family != family:
+                continue
+            signals = ', '.join(mode.signals) if mode.signals else '-'
+            lines.append(f'- {mode.mode_id}: {mode.name}. {mode.description} Signals: {signals}')
+    return '\n'.join(lines)
+
+
+def compile_classification_prompt(
+    manifest: TaxonomyManifest, request: ClassificationRequest,
+) -> Tuple[str, str]:
+    """Return ``(system, user)`` messages for one classification. Pure function.
+
+    The system message carries the manifest fingerprint so a stored prompt
+    hash pins the taxonomy it was compiled from.
+    """
+    system = (
+        'You are auditing ONE failed trajectory of an LLM agent. Name the decisive error: '
+        'the EARLIEST agent decision that made the failure unavoidable. Classify it into '
+        'exactly one mode of the taxonomy below, or abstain.\n\n'
+        f'TAXONOMY fingerprint={manifest.fingerprint} version={manifest.taxonomy_version}\n'
+        f'{_render_taxonomy(manifest)}\n\n'
+        'RULES\n'
+        '1. Judge only from the window shown. If the decisive step is not in it, abstain with '
+        'reason "decisive_step_not_in_window".\n'
+        '2. If no agent decision is wrong on the evidence and the failure is a tool, environment '
+        'or provider fault, abstain with reason "infrastructure_fault".\n'
+        '3. If two modes fit equally and you cannot separate them, abstain with reason '
+        '"ambiguous" and name both in the rationale.\n'
+        '4. evidence_quote must be copied verbatim from the window.\n\n'
+        'Answer with ONE JSON object and nothing else:\n'
+        '{"mode_id": "<mode id or null>", "submode": "<short phrase or null>", '
+        '"decisive_step": <integer step or null>, "evidence_quote": "<verbatim>", '
+        '"rationale": "<one or two sentences>", "confidence": <0.0-1.0>, '
+        '"abstain": <true|false>, "abstain_reason": "<one of '
+        + ', '.join(ABSTAIN_REASONS[:3]) + ' or null>"}'
+    )
+    completeness = 'complete' if request.window_complete else 'earlier steps omitted, tail kept'
+    hints = ''
+    if request.candidate_steps:
+        hints = '\nCANDIDATE STEPS (from a mechanical detector; not binding): ' + ', '.join(
+            str(step) for step in request.candidate_steps)
+    user = (
+        f'TRACE {request.trace_uid}\n'
+        f'TASK STATEMENT\n{request.task_statement or "(not provided)"}\n\n'
+        f'OUTCOME\n{request.outcome_text or "(not provided)"}\n\n'
+        f'TRAJECTORY ({completeness}){hints}\n{request.window}'
+    )
+    return system, user
+
+
+_FENCE = re.compile(r'```(?:json)?\s*(\{.*?\})\s*```', re.S)
+
+
+def _extract_object(text: str) -> Optional[Dict[str, Any]]:
+    """The first JSON object in ``text``: fenced, bare, or embedded in prose."""
+    if not text:
+        return None
+    candidates: List[str] = [m.group(1) for m in _FENCE.finditer(text)]
+    stripped = text.strip()
+    if stripped.startswith('{'):
+        candidates.insert(0, stripped)
+    start = text.find('{')
+    while start >= 0:
+        depth = 0
+        for index in range(start, len(text)):
+            char = text[index]
+            if char == '{':
+                depth += 1
+            elif char == '}':
+                depth -= 1
+                if depth == 0:
+                    candidates.append(text[start:index + 1])
+                    break
+        start = text.find('{', start + 1)
+        if len(candidates) > 8:
+            break
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _abstain(reason: str, raw: Optional[Dict[str, Any]] = None,
+             rationale: str = '') -> ClassificationResult:
+    if reason not in ABSTAIN_REASONS:
+        raise ValueError(f'unknown abstain reason {reason!r}')
+    return ClassificationResult(abstain=True, abstain_reason=reason, rationale=rationale,
+                                raw=raw or {})
+
+
+def parse_classification_response(text: str, manifest: TaxonomyManifest) -> ClassificationResult:
+    """Turn a judge reply into a :class:`ClassificationResult`; never raises.
+
+    A reply without a JSON object abstains with ``malformed_response``; one
+    whose fields do not fit abstains with ``unparsed``; one naming a mode the
+    manifest lacks abstains with ``unknown_mode`` and keeps the offending id in
+    ``raw``; an explicit ``"abstain": true`` is honoured with its reason
+    (an unknown reason becomes ``unparsed``).
+    """
+    parsed = _extract_object(text)
+    if parsed is None:
+        return _abstain('malformed_response')
+    try:
+        if parsed.get('abstain') is True:
+            reason = parsed.get('abstain_reason')
+            if reason not in ABSTAIN_REASONS:
+                reason = 'unparsed'
+            return ClassificationResult(
+                abstain=True, abstain_reason=str(reason),
+                rationale=str(parsed.get('rationale') or ''),
+                decisive_step=_int_or_none(parsed.get('decisive_step')),
+                confidence=_float(parsed.get('confidence')), raw=parsed,
+            )
+        mode_id = parsed.get('mode_id')
+        if not isinstance(mode_id, str) or not mode_id:
+            return _abstain('unparsed', parsed, 'reply named no mode and did not abstain')
+        family = manifest.family_of(mode_id)
+        if family is None:
+            return _abstain('unknown_mode', parsed, f'unknown mode {mode_id!r}')
+        return ClassificationResult(
+            mode_id=mode_id, family=family,
+            submode=_str_or_none(parsed.get('submode')),
+            decisive_step=_int_or_none(parsed.get('decisive_step')),
+            evidence_quote=str(parsed.get('evidence_quote') or ''),
+            rationale=str(parsed.get('rationale') or ''),
+            confidence=_float(parsed.get('confidence')), raw=parsed,
+        )
+    except (TypeError, ValueError) as exc:
+        return _abstain('unparsed', parsed, f'{type(exc).__name__}: {exc}')
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str) and value.strip().lstrip('-').isdigit():
+        return int(value.strip())
+    return None
+
+
+def _str_or_none(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _float(value: Any) -> float:
+    """A confidence in [0, 1]; anything unparseable is 0."""
+    try:
+        return min(1.0, max(0.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Agreement
+# --------------------------------------------------------------------------- #
+
+
+def cohens_kappa(labels_a: Sequence[Optional[str]],
+                 labels_b: Sequence[Optional[str]]) -> Optional[float]:
+    """Cohen's kappa between two labelers over the items both labelled.
+
+    Items where either side is ``None`` (abstained / unlabelled) are excluded.
+    Returns ``None`` when fewer than one paired item remains or when expected
+    agreement is 1 (a single category on both sides), where kappa is undefined.
+    """
+    if len(labels_a) != len(labels_b):
+        raise ValueError('label sequences must have the same length')
+    pairs = [(a, b) for a, b in zip(labels_a, labels_b) if a is not None and b is not None]
+    if not pairs:
+        return None
+    n = len(pairs)
+    observed = sum(1 for a, b in pairs if a == b) / n
+    categories = {a for a, _ in pairs} | {b for _, b in pairs}
+    expected = 0.0
+    for category in categories:
+        pa = sum(1 for a, _ in pairs if a == category) / n
+        pb = sum(1 for _, b in pairs if b == category) / n
+        expected += pa * pb
+    if expected >= 1.0:
+        return None
+    return (observed - expected) / (1.0 - expected)
+
+
+__all__ = [
+    'ABSTAIN_REASONS', 'MANIFEST_SCHEMA_VERSION', 'ClassificationRequest',
+    'ClassificationResult', 'ManifestMode', 'TaxonomyManifest', 'cohens_kappa',
+    'compile_classification_prompt', 'parse_classification_response', 'taxonomy_manifest',
+]

--- a/tests/test_taxonomy_manifest.py
+++ b/tests/test_taxonomy_manifest.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentdebug.schema.taxonomy import SEED_FAILURE_MODES
+from agentdebug.taxonomy_manifest import (
+    ABSTAIN_REASONS,
+    ClassificationRequest,
+    cohens_kappa,
+    compile_classification_prompt,
+    parse_classification_response,
+    taxonomy_manifest,
+)
+
+
+def test_manifest_is_deterministic_and_covers_every_family() -> None:
+    a, b = taxonomy_manifest(), taxonomy_manifest()
+    assert a.fingerprint == b.fingerprint and len(a.fingerprint) == 64
+    assert a.mode_ids() == sorted(a.mode_ids(), key=lambda m: (a.family_of(m), m))
+    assert set(a.families) == {mode.family for mode in SEED_FAILURE_MODES.values()}
+    assert len(a.modes) == len(SEED_FAILURE_MODES)
+    for family in ('verification', 'multiagent', 'multimodal'):
+        assert family in a.families, 'no family may be dropped from the reportable set'
+    json.dumps(a.to_dict())
+    assert a.source_revision['package'] == 'agentdebugx'
+
+
+def test_fingerprint_changes_when_a_definition_changes() -> None:
+    base = taxonomy_manifest()
+    modes = {k: v.model_copy() for k, v in SEED_FAILURE_MODES.items()}
+    key = next(iter(modes))
+    modes[key] = modes[key].model_copy(update={'description': modes[key].description + ' (edited)'})
+    assert taxonomy_manifest(modes).fingerprint != base.fingerprint
+    # a pure reordering of the input does not
+    reordered = dict(reversed(list(SEED_FAILURE_MODES.items())))
+    assert taxonomy_manifest(reordered).fingerprint == base.fingerprint
+
+
+def test_duplicate_or_mismatched_keys_are_refused() -> None:
+    modes = dict(SEED_FAILURE_MODES)
+    key = next(iter(modes))
+    modes['some.other.key'] = modes[key]
+    with pytest.raises(ValueError, match='duplicate mode id'):
+        taxonomy_manifest(modes)
+    mismatched = dict(SEED_FAILURE_MODES)
+    mismatched['renamed.key'] = mismatched.pop(key)
+    with pytest.raises(ValueError, match='disagrees'):
+        taxonomy_manifest(mismatched)
+
+
+def test_prompt_pins_the_fingerprint_and_carries_the_window() -> None:
+    manifest = taxonomy_manifest()
+    request = ClassificationRequest(trace_uid='tr-1', task_statement='find the cd',
+                                    outcome_text='failed', window='[step 0] look\n[step 1] done',
+                                    window_complete=False, candidate_steps=[1])
+    system, user = compile_classification_prompt(manifest, request)
+    assert manifest.fingerprint in system
+    for mode in manifest.modes:
+        assert mode.mode_id in system
+    assert 'earlier steps omitted' in user and 'CANDIDATE STEPS' in user and '[step 1] done' in user
+    assert (system, user) == compile_classification_prompt(manifest, request), 'pure function'
+
+
+@pytest.mark.parametrize('reply', [
+    '{"mode_id": "memory.retrieval_failure", "decisive_step": 1, "evidence_quote": "look", '
+    '"rationale": "it forgot", "confidence": 0.8, "abstain": false}',
+    'Sure! Here is my answer:\n```json\n{"mode_id": "memory.retrieval_failure", "decisive_step": "1", '
+    '"confidence": "0.8"}\n```\nHope this helps.',
+])
+def test_valid_replies_resolve_to_a_mode_and_family(reply: str) -> None:
+    result = parse_classification_response(reply, taxonomy_manifest())
+    assert not result.abstain
+    assert result.mode_id == 'memory.retrieval_failure' and result.family == 'memory'
+    assert result.decisive_step == 1 and result.confidence == pytest.approx(0.8)
+
+
+def test_unknown_mode_malformed_and_unparsed_replies_abstain() -> None:
+    manifest = taxonomy_manifest()
+    unknown = parse_classification_response('{"mode_id": "planning.zzz", "confidence": 0.9}', manifest)
+    assert unknown.abstain and unknown.abstain_reason == 'unknown_mode' and unknown.raw['mode_id'] == 'planning.zzz'
+    malformed = parse_classification_response('no json at all', manifest)
+    assert malformed.abstain and malformed.abstain_reason == 'malformed_response'
+    unparsed = parse_classification_response('{"confidence": 0.5}', manifest)
+    assert unparsed.abstain and unparsed.abstain_reason == 'unparsed'
+    explicit = parse_classification_response(
+        '{"abstain": true, "abstain_reason": "infrastructure_fault", "rationale": "tool died"}', manifest)
+    assert explicit.abstain and explicit.abstain_reason == 'infrastructure_fault' and explicit.mode_id is None
+    bad_reason = parse_classification_response('{"abstain": true, "abstain_reason": "because"}', manifest)
+    assert bad_reason.abstain_reason == 'unparsed'
+    assert all(reason in ABSTAIN_REASONS for reason in ('unknown_mode', 'malformed_response', 'unparsed'))
+
+
+def test_confidence_is_clamped_and_duplicate_json_keys_take_the_last() -> None:
+    manifest = taxonomy_manifest()
+    result = parse_classification_response(
+        '{"mode_id": "memory.hallucination", "confidence": 7, "mode_id": "memory.retrieval_failure"}', manifest)
+    assert result.mode_id == 'memory.retrieval_failure' and result.confidence == 1.0
+
+
+def test_cohens_kappa_matches_a_hand_computed_example() -> None:
+    a = ['x', 'x', 'y', 'y', 'x', None]
+    b = ['x', 'y', 'y', 'y', 'x', 'x']
+    # over the 5 paired items: observed 4/5; p(x): a 3/5, b 2/5; p(y): a 2/5, b 3/5
+    # expected = 0.24 + 0.24 = 0.48; kappa = (0.8 - 0.48) / 0.52
+    assert cohens_kappa(a, b) == pytest.approx((0.8 - 0.48) / 0.52)
+    assert cohens_kappa(['x', 'x'], ['x', 'x']) is None, 'undefined when expected agreement is 1'
+    assert cohens_kappa([None], ['x']) is None
+    with pytest.raises(ValueError):
+        cohens_kappa(['x'], ['x', 'y'])


### PR DESCRIPTION
## Motivation
AgentErrorData labels failed trajectories with a module-level error taxonomy and needs (a) a versioned, fingerprinted taxonomy artifact so stored labels stay interpretable when definitions change, (b) a strict classification schema with an explicit abstain outcome, and (c) a prompt compiler and parser it can wrap with its own provider calls, budgets and append-only storage. It carries local five-family definitions today, which silently drop the upstream `verification`, `multiagent`, `multimodal` and `observation` families (see the alignment note in that repo). This PR provides the upstream contract.

## Design (`agentdebug/taxonomy_manifest.py`; `agentdebug.taxonomy` is already a compat alias of `agentdebug.schema`, hence the name)
- `taxonomy_manifest(modes=None, *, taxonomy_version=None, source_revision=None) -> TaxonomyManifest`: modes from `SEED_FAILURE_MODES`, sorted by (family, id), fingerprint = sha256 of the canonical JSON of the modes (id, name, family, description, signals, source), `source_revision` from `agentdebug.provenance()`; duplicate ids and key/id disagreement are refused; every family kept.
- `ClassificationRequest` (trace uid, task statement, outcome text, rendered window, completeness flag, candidate steps) and `ClassificationResult` (mode_id, family, submode, decisive_step, evidence_quote, rationale, confidence clamped to [0,1], `abstain` + `abstain_reason` from `ABSTAIN_REASONS`, raw object kept).
- `compile_classification_prompt(manifest, request) -> (system, user)`: pure; the system prompt pins the fingerprint and lists every mode by family; rules for abstaining on infrastructure faults, out-of-window decisive steps and ambiguity.
- `parse_classification_response(text, manifest)`: never raises; fenced/bare/embedded JSON, unknown mode → `unknown_mode`, no JSON → `malformed_response`, unfit fields → `unparsed`, explicit abstain honoured.
- `cohens_kappa(a, b)`; `None` where undefined.

## Tests
`tests/test_taxonomy_manifest.py` (9): deterministic fingerprint across builds and input order, fingerprint drift on a definition edit, duplicate/mismatched keys refused, prompt pins the fingerprint and carries the window, valid replies (bare and fenced with prose), unknown/malformed/unparsed/explicit abstentions, confidence clamping and duplicate JSON keys, kappa on a hand-computed example and the undefined case. ruff clean; mypy reports only the pydantic `BaseModel`-is-Any class errors that upstream's own models produce in this environment.

## Consumer
AgentErrorData `scripts/label_error_modules.py` becomes a thin adapter (provider calls, budget, trace binding, sidecar writes) over this contract and records fingerprint + source revision + prompt hash on every row (new sidecar namespace; v1001 rows untouched).