### PR TITLE
bump: version 0.4.0 → 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentdebugx"
-version = "0.4.0"
+version = "0.5.0"
 description = "Portable error analysis, tracing, and recovery framework for agentic AI systems. Import as `agentdebug`."
 authors = ["ULab @ UIUC <ulab@illinois.edu>"]
 license = "MIT"

--- a/src/agentdebug/__init__.py
+++ b/src/agentdebug/__init__.py
@@ -291,7 +291,7 @@ __all__ = [
     'write_converted_trajectory',
 ]
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 _COMPAT_MODULE_ALIASES = {
     'agentdebug.models': _core_models_mod,


### PR DESCRIPTION
Minor release: new public API since 0.4.0, all additive.

- `agentdebug.diagnose.detect.evidence`: `locate_quote`, `resolve_anchor`, `grounds_trajectory`, `annotate_evidence_regions` (#14)
- `agentdebug.ingest.native_protocol`: `native_tool_protocol_violations`, `native_tool_message_violations`; `convert_payload(strict_native=True)` (#15)
- `agentdebug.provenance.provenance()` (#16)
- `agentdebug.diagnose.attribute.NO_FALLBACK`, `NoFallback`, `AttributionUnavailable` (#17)
- `agentdebug.taxonomy_manifest`: `taxonomy_manifest`, `ClassificationRequest/Result`, `compile_classification_prompt`, `parse_classification_response`, `cohens_kappa` (#18)

Version bumped in `pyproject.toml` and `src/agentdebug/__init__.py`; wheel and sdist build and pass `twine check`. Publication to PyPI follows the merge and the `v0.5.0` tag. Consumer: AgentErrorData moves its pin to `agentdebugx>=0.5.0,<0.6`.