### PR TITLE
bump: version 0.5.0 → 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentdebugx"
-version = "0.5.0"
+version = "0.5.1"
 description = "Portable error analysis, tracing, and recovery framework for agentic AI systems. Import as `agentdebug`."
 authors = ["ULab @ UIUC <ulab@illinois.edu>"]
 license = "MIT"

--- a/src/agentdebug/__init__.py
+++ b/src/agentdebug/__init__.py
@@ -291,7 +291,7 @@ __all__ = [
     'write_converted_trajectory',
 ]
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 _COMPAT_MODULE_ALIASES = {
     'agentdebug.models': _core_models_mod,


### PR DESCRIPTION
Patch release: `taxonomy_manifest` works under pydantic 1.x (dict() fallback); the GUI suite and the GUI boundary test are skipped on the pydantic v1 matrix; the Ruff job is green (#20, #21). No API change. Publication to PyPI follows the merge and the `v0.5.1` tag.