### PR TITLE
detect.evidence: locate_quote forgives renderer role labels and quotation marks

### DIFF
--- a/src/agentdebug/diagnose/detect/evidence.py
+++ b/src/agentdebug/diagnose/detect/evidence.py
@@ -39,7 +39,17 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 from agentdebug.schema import (
     AgentEvent,
@@ -341,7 +351,7 @@ def annotate_quote_verification(
     return annotated
 
 
-def quote_verification_summary(findings: Iterable[FailureFinding]) -> dict:
+def quote_verification_summary(findings: Iterable[FailureFinding]) -> Dict[str, int]:
     """Counts by verification state, for reporting a detector's grounding rate.
 
     The ratio of ``verified`` to ``verified + unsupported`` is a measurable
@@ -384,8 +394,17 @@ def quote_verification_summary(findings: Iterable[FailureFinding]) -> dict:
 # of a real event are different defects with different fixes.
 #
 # Nothing below changes what :func:`verify_finding_quotes` accepts. The
-# ``normalized`` rung applies the same normalisation, so a quote that verifies
-# also locates; the extra information is *where*.
+# ``normalized`` rung applies the same normalisation first, so a quote that
+# verifies also locates; the extra information is *where*. It then goes one
+# step wider than verification -- quotation marks are dropped on both sides
+# (see :func:`_canon`) -- so a quote may locate without verifying. Measured on
+# 1,500 evidence quotes from a consumer's debug corpus (AgentErrorData,
+# ``scripts/evidence_region_vs_upstream.py``), 402 quotes the consumer's own
+# rung ladder anchored were not grounded here; 337 of them differed from the
+# stored field in nothing but a renderer's role label (``Observation: ...``,
+# ``step 8 action: ...``) and 11 more in nothing but the kind of quotation
+# mark, which is why both are treated as framing rather than content. After
+# this change 54 remain, and those are real edits or two-field composites.
 # ---------------------------------------------------------------------------
 
 #: Rungs, strictest first. A quote is credited to the first rung that locates it.
@@ -393,7 +412,10 @@ def quote_verification_summary(findings: Iterable[FailureFinding]) -> dict:
 #: ``normalized`` -- substring after the normalisation ``verify_finding_quotes``
 #: applies (JSON escapes, whitespace, a trailing truncation marker) and after
 #: removing the framing a renderer puts around an event -- ``[step 3]``,
-#: ``event_id=evt_...``, ``output=`` -- which a model copying a line copies too.
+#: ``event_id=evt_...``, ``output=``, ``Observation:`` -- which a model copying
+#: a line copies too; failing that, with quotation marks dropped on both
+#: sides, since a stored ``repr`` and a model's JSON re-quoting of it differ
+#: in nothing else.
 #: ``anchored`` -- the text was found nowhere, but the quote (or the caller)
 #: named an event id that exists. A pointer, not a transcription.
 #: ``unresolvable`` -- neither the text nor an anchor places it.
@@ -427,20 +449,38 @@ ANCHOR_ELSEWHERE = 'elsewhere'
 
 _EVENT_FIELDS = ('input', 'output', 'error')
 
+#: The label a renderer prints in front of an event's text (``Thought:``,
+#: ``Action:``, ``Observation:``, ``Feedback:``), and the ones models add
+#: themselves when reproducing a line (``env:``, ``error:``, ``solver:``,
+#: ``verifier signal:``). A renderer that folds the error field into the
+#: label -- ``Observation (tool error: unknown_carrier): Rejected.`` -- is
+#: covered by the optional parenthetical. The label is framing; the text
+#: after the colon must still match a stored field.
+_ROLE_LABEL = (
+    r'(?:thought|action|observation|feedback|env|error|solver|signal|user|executor'
+    r'|verifier[ _]signal|verification|verifier)(?:\s*\([^)]*\))?\s*:'
+)
+#: The event-id forms the built-in renderers print (``event_id=evt_x``) and
+#: the ones models write when asked to cite (``evt_x: ...``, ``(evt_x) ...``,
+#: ``[evt_x][agent][kind] ...``).
+_EVENT_REF = (
+    r'\[(?P<bracket>evt_\w+)\](?:\[[^\]]*\]){0,2}'
+    r'|\((?P<paren>evt_\w+)\)'
+    r'|event_id\s*=\s*(?P<kw>[^\s,;:]+)'
+    r'|(?P<colon>evt_\w+)\s*[:\-]'
+)
 #: Framing a renderer puts around an event, or a model adds when reproducing a
 #: line. Anchored on the start of the quote, so only a leading frame is
-#: removed and the quoted content itself must still match. The event-id forms
-#: are the ones the built-in renderers print (``event_id=evt_x``) and the ones
-#: models write when asked to cite (``evt_x: ...``, ``(evt_x) ...``,
-#: ``[evt_x][agent][kind] ...``).
+#: removed and the quoted content itself must still match. A bare ``step 3``
+#: (no colon) counts as framing only when an event reference or a role label
+#: follows it, so ``step 3 of the plan`` keeps its first two words.
 _FRAME = re.compile(
     r'^\s*'
-    r'(?:\[step\s+\d+\]|step\s+\d+\s*[:\-])?\s*'
-    r'(?:\[(?P<bracket>evt_\w+)\](?:\[[^\]]*\]){0,2}'
-    r'|\((?P<paren>evt_\w+)\)'
-    r'|event_id=(?P<kw>[^\s,;:]+)'
-    r'|(?P<colon>evt_\w+)\s*[:\-])?\s*'
+    r'(?:\[step\s+\d+\]|step\s+\d+\s*[:\-]'
+    r'|step\s+\d+(?=\s+(?:[\[(]?evt_|event_id\s*=|' + _ROLE_LABEL + r')))?\s*'
+    r'(?:' + _EVENT_REF + r')?\s*'
     r'(?:(?:type|agent)=\S+\s*)*'
+    r'(?:' + _ROLE_LABEL + r')?\s*'
     r'(?:(?:input|output|error|metadata)\s*[:=])?\s*',
     re.IGNORECASE,
 )
@@ -497,6 +537,13 @@ def _norm_with_map(text: str) -> Tuple[str, List[Tuple[int, int]]]:
     spans = [(i, i + 1) for i in range(len(text))]
     for seq, char in _ESCAPES:
         chars, spans = _replace_with_map(chars, spans, seq, char)
+    return _collapse_ws_with_map(chars, spans)
+
+
+def _collapse_ws_with_map(
+    chars: Sequence[str], spans: Sequence[Tuple[int, int]]
+) -> Tuple[str, List[Tuple[int, int]]]:
+    """``_WS.sub(' ', text).strip()`` over a character list, spans carried along."""
     out_chars: List[str] = []
     out_spans: List[Tuple[int, int]] = []
     i = 0
@@ -519,6 +566,42 @@ def _norm_with_map(text: str) -> Tuple[str, List[Tuple[int, int]]]:
         out_chars.pop()
         out_spans.pop()
     return ''.join(out_chars), out_spans
+
+
+#: Quotation marks, straight and typographic. A stored tool call is a Python
+#: ``repr`` with single quotes; a model re-quotes it as JSON with double
+#: quotes, or a chat surface curls them. Measured on the consumer corpus
+#: above, 11 quotes located only once these were dropped. Case, wording and
+#: punctuation are still not normalised.
+_QUOTE_MARKS = '"\'`\u2018\u2019\u201c\u201d'
+_QUOTE_CHARS = re.compile('[' + re.escape(_QUOTE_MARKS) + ']')
+
+
+def _canon(text: str) -> str:
+    """:func:`_norm`, then quotation marks dropped and whitespace re-collapsed.
+
+    Dropping a mark can leave two spaces adjacent (``a ' b``) or one at an
+    end (``'x'``), so the collapse runs again; both sides go through the same
+    function, so what matters is only that it is deterministic.
+    """
+    return _WS.sub(' ', _QUOTE_CHARS.sub('', _norm(text))).strip()
+
+
+def _canon_quote(text: str) -> str:
+    """:func:`_canon` of a model-supplied quote, truncation marker removed first."""
+    return _canon(_norm_quote(text))
+
+
+def _canon_with_map(text: str) -> Tuple[str, List[Tuple[int, int]]]:
+    """:func:`_canon`, plus the offset map :func:`_norm_with_map` provides.
+
+    Built on the ``_norm`` map, so the two stay equivalent by construction:
+    the mapped characters are filtered and re-collapsed exactly as ``_canon``
+    filters and re-collapses the string.
+    """
+    mapped, spans = _norm_with_map(text)
+    kept = [(c, span) for c, span in zip(mapped, spans) if c not in _QUOTE_MARKS]
+    return _collapse_ws_with_map([c for c, _ in kept], [span for _, span in kept])
 
 
 def _replace_with_map(
@@ -675,50 +758,28 @@ def locate_quote(
     if anchor_event is not None:
         order.sort(key=lambda i: events[i] is not anchor_event)
 
-    # Rung 1: the quote as given, verbatim.
-    exact = quote
-    for i in order:
-        found = _find_in_event(events[i], i, exact, shown, normalized=False)
-        if found is not None:
-            return finish(found)
-    if trajectory.goal and exact in trajectory.goal:
-        start = trajectory.goal.index(exact)
-        return finish(QuoteLocation(
-            rung=RUNG_EXACT, region=REGION_GOAL, span=(start, start + len(exact)),
-            text=exact,
-        ))
-    if inner and inner != exact:
-        for i in order:
-            found = _find_in_event(events[i], i, inner, shown, normalized=False)
-            if found is not None:
-                return finish(found)
-        if trajectory.goal and inner in trajectory.goal:
-            start = trajectory.goal.index(inner)
-            return finish(QuoteLocation(
-                rung=RUNG_EXACT, region=REGION_GOAL, span=(start, start + len(inner)),
-                text=inner,
-            ))
-
-    # Rung 2: after the normalisation `verify_finding_quotes` applies, with the
-    # quote's own framing removed. The unframed form is tried first so that a
-    # quote copied from a rendering that includes the frame still resolves
-    # against `shown`.
-    needles: List[str] = []
-    for candidate in (_norm_quote(quote), _norm_quote(inner)):
-        if candidate and candidate not in needles:
-            needles.append(candidate)
-    for needle in needles:
-        for i in order:
-            found = _find_in_event(events[i], i, needle, shown, normalized=True)
-            if found is not None:
-                return finish(found)
-        if trajectory.goal:
-            span = _find_normalized(needle, trajectory.goal)
-            if span is not None:
-                return finish(QuoteLocation(
-                    rung=RUNG_NORMALIZED, region=REGION_GOAL, span=span,
-                    text=trajectory.goal[span[0]:span[1]],
-                ))
+    # Rung 1: the quote as given, verbatim, then with its own framing removed.
+    # Rung 2: after the normalisation `verify_finding_quotes` applies, then --
+    # wider than verification -- with quotation marks dropped. At every step
+    # the framed form is tried before the unframed one, so that a quote copied
+    # from a rendering that includes the frame still resolves against `shown`.
+    for rung, prepare, finder in _LADDER:
+        needles: List[str] = []
+        for candidate in (prepare(quote), prepare(inner)):
+            if candidate and candidate not in needles:
+                needles.append(candidate)
+        for needle in needles:
+            for i in order:
+                found = _find_in_event(events[i], i, needle, shown, rung, finder)
+                if found is not None:
+                    return finish(found)
+            if trajectory.goal:
+                span = finder(needle, trajectory.goal)
+                if span is not None:
+                    return finish(QuoteLocation(
+                        rung=rung, region=REGION_GOAL, span=span,
+                        text=trajectory.goal[span[0]:span[1]],
+                    ))
 
     # Rung 3: no text located; a real anchor still places the claim at an event.
     if anchor_event is not None:
@@ -732,20 +793,56 @@ def locate_quote(
     return finish(QuoteLocation(rung=RUNG_UNRESOLVABLE, region=REGION_NONE))
 
 
-def _find_normalized(needle: str, haystack: str) -> Optional[Tuple[int, int]]:
-    """Span of ``needle`` in ``haystack`` after ``_norm``, mapped back to raw offsets.
+_Finder = Callable[[str, str], Optional[Tuple[int, int]]]
+_Mapper = Callable[[str], Tuple[str, List[Tuple[int, int]]]]
 
-    The regex-based ``_norm`` is the fast pre-check; the offset map is built
-    only for a haystack that contains the needle.
+
+def _find_mapped(
+    needle: str, haystack: str, canonical: Callable[[str], str], with_map: _Mapper
+) -> Optional[Tuple[int, int]]:
+    """Span of an already-canonical ``needle`` in ``haystack``, in raw offsets.
+
+    The regex-based ``canonical`` is the fast pre-check; the offset map is
+    built only for a haystack that contains the needle.
     """
-    if not needle or needle not in _norm(haystack):
+    if not needle or needle not in canonical(haystack):
         return None
-    mapped, spans = _norm_with_map(haystack)
+    mapped, spans = with_map(haystack)
     start = mapped.find(needle)
-    if start < 0:  # pragma: no cover - the map is equivalent to _norm by construction
+    if start < 0:  # pragma: no cover - the map is equivalent by construction
         return None
     end = start + len(needle)
     return spans[start][0], spans[end - 1][1]
+
+
+def _find_normalized(needle: str, haystack: str) -> Optional[Tuple[int, int]]:
+    """Span of ``needle`` in ``haystack`` after ``_norm``, mapped back to raw offsets."""
+    return _find_mapped(needle, haystack, _norm, _norm_with_map)
+
+
+def _find_canon(needle: str, haystack: str) -> Optional[Tuple[int, int]]:
+    """Span of ``needle`` in ``haystack`` after ``_canon``, mapped back to raw offsets."""
+    return _find_mapped(needle, haystack, _canon, _canon_with_map)
+
+
+def _find_exact(needle: str, haystack: str) -> Optional[Tuple[int, int]]:
+    start = haystack.find(needle)
+    if start < 0:
+        return None
+    return start, start + len(needle)
+
+
+def _verbatim(text: str) -> str:
+    return text
+
+
+#: The rungs :func:`locate_quote` climbs, strictest first: how the quote is
+#: prepared, and how a haystack is searched for it.
+_LADDER: Tuple[Tuple[str, Callable[[str], str], _Finder], ...] = (
+    (RUNG_EXACT, _verbatim, _find_exact),
+    (RUNG_NORMALIZED, _norm_quote, _find_normalized),
+    (RUNG_NORMALIZED, _canon_quote, _find_canon),
+)
 
 
 def _find_in_event(
@@ -753,14 +850,14 @@ def _find_in_event(
     index: int,
     needle: str,
     shown: Optional[Mapping[str, str]],
-    normalized: bool,
+    rung: str,
+    finder: _Finder,
 ) -> Optional[QuoteLocation]:
-    rung = RUNG_NORMALIZED if normalized else RUNG_EXACT
     for field in _EVENT_FIELDS:
         text = _field_text(event, field)
         if not text:
             continue
-        span = _find_normalized(needle, text) if normalized else _find_exact(needle, text)
+        span = finder(needle, text)
         if span is not None:
             return QuoteLocation(
                 rung=rung, region=REGION_EVENT, event_id=event.event_id,
@@ -770,7 +867,7 @@ def _find_in_event(
             )
     rendered = (shown or {}).get(event.event_id)
     if rendered:
-        span = _find_normalized(needle, rendered) if normalized else _find_exact(needle, rendered)
+        span = finder(needle, rendered)
         if span is not None:
             return QuoteLocation(
                 rung=rung, region=REGION_SHOWN, event_id=event.event_id,
@@ -779,13 +876,6 @@ def _find_in_event(
                 text=rendered[span[0]:span[1]],
             )
     return None
-
-
-def _find_exact(needle: str, haystack: str) -> Optional[Tuple[int, int]]:
-    start = haystack.find(needle)
-    if start < 0:
-        return None
-    return start, start + len(needle)
 
 
 @dataclass(frozen=True)

--- a/tests/test_detect_evidence_regions.py
+++ b/tests/test_detect_evidence_regions.py
@@ -25,6 +25,8 @@ from agentdebug.diagnose.detect.evidence import (
     RUNG_EXACT,
     RUNG_NORMALIZED,
     RUNG_UNRESOLVABLE,
+    _canon,
+    _canon_with_map,
     _norm,
     _norm_with_map,
     annotate_evidence_regions,
@@ -265,6 +267,173 @@ class TestJsonEscapedSource:
         assert grounding.grounded is True
 
 
+class TestRendererFrames:
+    """A model copying a rendered line copies the renderer's label with it.
+
+    ``Observation: ...``, ``step 8 action: ...``, ``Step 4 [evt_x] env: ...``
+    are what consumers' renderers print and what models write back. Measured
+    on 1,500 evidence quotes from one such consumer, 402 quotes that its own
+    checker anchored were not grounded here, and 337 of them differed from a
+    stored field in nothing but such a label. The label is framing; the text
+    after it must still match.
+    """
+
+    @pytest.fixture
+    def fridge(self) -> AgentTrajectory:
+        traj = AgentTrajectory(trace_id='t6')
+        traj.add_event(AgentEvent(
+            event_id='evt_call', trace_id='t6', event_type=EventType.TOOL_CALL,
+            step_index=0, input={'tool': 'open', 'target': 'fridge 1'},
+        ))
+        traj.add_event(AgentEvent(
+            event_id='evt_res', trace_id='t6', event_type=EventType.TOOL_RESULT,
+            step_index=0, output='Rejected. No carrier latam. Available: atlas.',
+            error='unknown_carrier',
+        ))
+        return traj
+
+    def test_a_role_label_is_framing_and_the_text_is_exact(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        loc = locate_quote(trajectory, f'Observation: {DESK}')
+        assert loc.rung == RUNG_EXACT
+        assert (loc.event_id, loc.field, loc.span) == ('evt_desk', 'output', (0, len(DESK)))
+        assert loc.text == DESK
+
+    def test_an_action_label_over_a_repr_input(self, fridge: AgentTrajectory) -> None:
+        """A tool call is stored as a dict; the renderer prints its ``repr``."""
+        loc = locate_quote(fridge, "Action: {'tool': 'open', 'target': 'fridge 1'}")
+        assert (loc.rung, loc.event_id, loc.field) == (RUNG_EXACT, 'evt_call', 'input')
+        assert loc.text == repr({'tool': 'open', 'target': 'fridge 1'})
+
+    def test_a_label_that_folds_in_the_error_field(self, fridge: AgentTrajectory) -> None:
+        """``Observation (tool error: x): y`` is one rendered line over two fields."""
+        loc = locate_quote(
+            fridge, 'Observation (tool error: unknown_carrier): Rejected. No carrier latam.'
+        )
+        assert (loc.rung, loc.event_id, loc.field) == (RUNG_EXACT, 'evt_res', 'output')
+        assert loc.text == 'Rejected. No carrier latam.'
+
+    @pytest.mark.parametrize('quote', [
+        'step 1 observation: you see a cd 3',
+        'Step 1 Observation: you see a cd 3',
+        '[step 1] env: you see a cd 3',
+        'step 1: env: you see a cd 3',
+    ])
+    def test_a_step_number_before_a_label_needs_no_colon(
+        self, trajectory: AgentTrajectory, quote: str
+    ) -> None:
+        loc = locate_quote(trajectory, quote)
+        assert (loc.rung, loc.event_id) == (RUNG_EXACT, 'evt_desk')
+        assert loc.anchor_status == ANCHOR_NOT_DECLARED
+
+    def test_a_step_number_before_an_event_reference_and_a_label(
+        self, trajectory: AgentTrajectory
+    ) -> None:
+        loc = locate_quote(trajectory, 'Step 1 [evt_desk] env: you see a cd 3')
+        assert (loc.rung, loc.event_id) == (RUNG_EXACT, 'evt_desk')
+        assert (loc.anchor, loc.anchor_status) == ('evt_desk', ANCHOR_RESOLVED)
+
+    def test_a_bare_step_number_is_not_framing(self) -> None:
+        """``step 3 of the plan`` is prose; its first two words are content."""
+        traj = AgentTrajectory(trace_id='t7')
+        traj.add_event(AgentEvent(
+            event_id='evt_a', trace_id='t7', event_type=EventType.AGENT_STEP,
+            step_index=3, output='of the plan was executed',
+        ))
+        assert locate_quote(traj, 'step 3 of the plan was executed').rung == RUNG_UNRESOLVABLE
+        assert locate_quote(traj, 'step 3').rung == RUNG_UNRESOLVABLE
+
+    def test_the_label_alone_locates_nothing(self, trajectory: AgentTrajectory) -> None:
+        assert locate_quote(trajectory, 'Observation:').rung == RUNG_UNRESOLVABLE
+
+
+class TestQuotationMarks:
+    """A stored ``repr`` uses single quotes; a model re-quotes it as JSON.
+
+    Measured on the same 1,500 quotes, 11 located only once quotation marks
+    were dropped. They locate under ``normalized``, with a span into the raw
+    field, and they still do not *verify*: the ``quote_verified`` contract is
+    untouched.
+    """
+
+    @pytest.fixture
+    def fridge(self) -> AgentTrajectory:
+        traj = AgentTrajectory(trace_id='t8')
+        traj.add_event(AgentEvent(
+            event_id='evt_call', trace_id='t8', event_type=EventType.TOOL_CALL,
+            step_index=0, input={'tool': 'open', 'target': 'fridge 1'},
+            error="PermissionError: 'fridge 1' is locked",
+        ))
+        return traj
+
+    def test_json_quotes_locate_a_repr_input(self, fridge: AgentTrajectory) -> None:
+        quote = '{"tool": "open", "target": "fridge 1"}'
+        loc = locate_quote(fridge, quote)
+        assert (loc.rung, loc.event_id, loc.field) == (RUNG_NORMALIZED, 'evt_call', 'input')
+        raw = repr({'tool': 'open', 'target': 'fridge 1'})
+        assert loc.span is not None and raw[loc.span[0]:loc.span[1]] == loc.text == raw
+        assert _canon(loc.text) == _canon(quote)
+
+    def test_typographic_quotes_locate_straight_ones(self, fridge: AgentTrajectory) -> None:
+        loc = locate_quote(fridge, 'PermissionError: \u201cfridge 1\u201d is locked')
+        assert (loc.rung, loc.field) == (RUNG_NORMALIZED, 'error')
+        assert loc.text == "PermissionError: 'fridge 1' is locked"
+
+    def test_a_frame_and_re_quoting_together(self, fridge: AgentTrajectory) -> None:
+        loc = locate_quote(fridge, 'step 0 action: {"tool": "open", "target": "fridge 1"}')
+        assert (loc.rung, loc.field) == (RUNG_NORMALIZED, 'input')
+
+    def test_marks_are_ignored_not_matched_across(self, fridge: AgentTrajectory) -> None:
+        """Dropping marks must not let ``fridge 1`` bridge two fields or invent text."""
+        assert locate_quote(fridge, '{"tool": "open", "target": "fridge 2"}').rung == (
+            RUNG_UNRESOLVABLE
+        )
+
+    def test_verification_is_unchanged(self, fridge: AgentTrajectory) -> None:
+        """Locates, and does not verify: the wider rung is location-only."""
+        quote = '{"tool": "open", "target": "fridge 1"}'
+        assert locate_quote(fridge, quote).grounded
+        finding = FailureFinding(
+            failure_mode=MODE, event_id='evt_call', step_index=0,
+            wrong_content_quote=quote,
+        )
+        assert verify_finding_quotes(finding, fridge) is False
+
+
+class TestWhatStillDoesNotLocate:
+    """Widening the normalisation must not start crediting non-quotes.
+
+    Prose, statistics, step pointers and absence claims are not transcriptions
+    of anything, and a consumer that rejects them must be able to keep doing
+    so after routing through :func:`locate_quote`. Measured on the consumer
+    corpus, spans its checker files under a not-a-quote rung and this
+    function grounds went from 54 to 60, and all six newcomers are verbatim
+    text: five quote the run-end verifier signal behind a ``Verifier
+    signal:`` label, one differs in a curly apostrophe. No statistic, step
+    pointer or absence claim crossed.
+    """
+
+    @pytest.mark.parametrize('quote', [
+        'the agent never looked at the desk',        # absence claim
+        'steps=4 n_tool_calls=1',                     # statistics
+        'step 1',                                     # step pointer
+        'turn 2',                                     # step pointer
+        'the desk holds three items',                 # prose about the event
+        'Observation: the desk holds three items',    # prose behind a label
+        '"the desk holds three items"',               # prose in quotation marks
+    ])
+    def test_not_a_quote_is_unresolvable(
+        self, trajectory: AgentTrajectory, quote: str
+    ) -> None:
+        loc = locate_quote(trajectory, quote)
+        assert loc.rung == RUNG_UNRESOLVABLE
+        assert not loc.grounded
+
+    def test_case_is_still_content(self, trajectory: AgentTrajectory) -> None:
+        assert locate_quote(trajectory, 'You See A CD 3').rung == RUNG_UNRESOLVABLE
+
+
 class TestNormalizationMap:
     @pytest.mark.parametrize('text', [
         'plain',
@@ -285,6 +454,28 @@ class TestNormalizationMap:
             assert 0 <= start < end <= len(text)
             if char != ' ':
                 assert _norm(text[start:end]) == char
+
+    @pytest.mark.parametrize('text', [
+        'plain',
+        '"quoted" text',
+        "it's ' alone '",
+        '\u201ccurly\u201d and \u2018single\u2019 and `back`',
+        'a " b',
+        "'",
+        '\'"\'',
+        '',
+        '  "padded"  ',
+        'escaped \\" mark',
+    ])
+    def test_the_canon_map_reproduces_canon_exactly(self, text: str) -> None:
+        """Same contract as ``_norm``: the mapped text IS ``_canon``."""
+        mapped, spans = _canon_with_map(text)
+        assert mapped == _canon(text)
+        assert len(spans) == len(mapped)
+        for (start, end), char in zip(spans, mapped):
+            assert 0 <= start < end <= len(text)
+            if char != ' ':
+                assert _canon(text[start:end]) == char
 
 
 class TestGroundsTrajectory:


### PR DESCRIPTION
## What

`locate_quote`'s `normalized` rung now forgives two more things a model copies from a rendered line that are not content:

1. **A renderer's role label** in front of the text: `Observation: ...`, `Action: {...}`, `step 8 action: ...`, `Step 4 [evt_x] env: ...`, `Observation (tool error: unknown_carrier): Rejected...`. `_FRAME` accepts the label after the step / event-id frame, and a bare `step N` (no colon) only when an event reference or a label follows it, so `step 3 of the plan` keeps its first two words. The content after the label must still match a stored field.
2. **The kind of quotation mark.** A tool call is stored as a dict and searched as its `repr` (single quotes); models re-quote it as JSON (double quotes) or a chat surface curls them. A second needle with `' " ` ‘ ’ “ ”` dropped on both sides is tried after the existing whitespace/escape normalisation. `_canon` / `_canon_with_map` are built on `_norm` / `_norm_with_map` and tested to be equivalent, so the span still indexes the raw field.

Case, wording and punctuation remain content. **`verify_finding_quotes` is unchanged**: a quote that verifies still locates; a quote that locates only under the quote-mark step does not verify, and `TestQuotationMarks::test_verification_is_unchanged` pins that. If you would rather widen verification too, that is a separate decision that moves reported grounding rates, so it is not in this PR.

Also: rungs 1–2 are one ladder (`_LADDER`), `_find_in_event` takes the finder instead of a bool, and `quote_verification_summary` returns `Dict[str, int]` (the one mypy error on the file).

## Why, measured

1,500 evidence quotes from 58 debug-attempt datasets in AgentErrorData (`scripts/evidence_region_vs_upstream.py`), its own rung ladder `classify_span(quote, rendered)` against `locate_quote(...).rung` on the converted trajectory:

| | before (0.5.1) | after (this branch) |
|---|---:|---:|
| consumer-anchored | 1,199 | 1,199 |
| upstream grounded (`exact` or `normalized`) | 853 | 1,208 |
| both | 797 | 1,145 |

Of the 402 consumer-anchored quotes upstream could not ground, 337 differed from the stored field in nothing but a role label, 11 more in nothing but quotation marks; no case folding was needed. The 54 that remain are real edits (`Verifer signal:`, reordered words) or one rendered line composed from two fields (`!! action_parse_error: ... | raw output: ...`, 15 cases), which no normalisation should bridge.

**What must not move:** spans the consumer files under a not-a-quote rung (prose, statistics, step pointers, absence claims, fabricated) that upstream grounds: **54 → 60** (`exact` 44 → 49, `normalized` 10 → 11). All six newcomers are verbatim text, and I checked each:

- five are the run-end verifier signal quoted behind a `Verifier signal:` label (`Verifier signal: fulfilment incorrect: no shipment registered`, found `exact` in the `run.end` event's `output`); the consumer calls those "prose" only because its render never prints `run.end`, and 29 of the same kind without the label were already `exact` before this change;
- one is `Let’s look around. Use look.` against the stored `Let's look around. Use look.` (an agent step).

No statistic, step pointer or absence claim crossed. `TestWhatStillDoesNotLocate` covers those classes.

## Tests

`tests/test_detect_evidence_regions.py`: `TestRendererFrames` (label as framing, label over a `repr` input, label that folds in the error field, step number before a label / before an event reference, bare `step N` is not framing, a label alone locates nothing), `TestQuotationMarks` (JSON over `repr`, typographic over straight, frame + re-quoting together, marks do not bridge fields, verification unchanged), `TestWhatStillDoesNotLocate` (absence claim, statistics, step / turn pointer, prose bare / behind a label / in quotation marks, case is still content), and `_canon_with_map` reproduces `_canon` exactly.

- `PYTHONPATH=src pytest tests -q --ignore=tests/gui`: 666 passed, 7 skipped (before the new tests); `tests/test_detect_evidence_regions.py`: 67 passed
- `ruff check src/agentdebug/diagnose/detect/evidence.py tests/test_detect_evidence_regions.py`: clean
- `mypy src/agentdebug/diagnose/detect/evidence.py`: no issues (was 1 error on `main`)
- pydantic v1: no `model_dump` / `model_copy` / `field_validator` in the change; the module touches no pydantic API.
