### PR TITLE
bump: version 0.5.1 → 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentdebugx"
-version = "0.5.1"
+version = "0.5.2"
 description = "Portable error analysis, tracing, and recovery framework for agentic AI systems. Import as `agentdebug`."
 authors = ["ULab @ UIUC <ulab@illinois.edu>"]
 license = "MIT"

--- a/src/agentdebug/__init__.py
+++ b/src/agentdebug/__init__.py
@@ -291,7 +291,7 @@ __all__ = [
     'write_converted_trajectory',
 ]
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 
 _COMPAT_MODULE_ALIASES = {
     'agentdebug.models': _core_models_mod,


### PR DESCRIPTION
Patch release for #23 (`locate_quote`: renderer role labels stripped after the frame; quotation-mark-insensitive needle on the `normalized` rung; measured on 1,500 real quotes: grounded 853 → 1,208, both-with-consumer-gate 797 → 1,145). `verify_finding_quotes` unchanged. Publication to PyPI follows the merge and the `v0.5.2` tag.